### PR TITLE
(Editorial) Duplicate "conforms to"

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,8 +496,7 @@ in the Data Integrity Specification Registries [TBD - DIS-REGISTRIES].
                 <dd>
                   <p>
 The value of the `id` property for a <a>verification
-method</a> MUST be a <a data-cite="INFRA#string">string</a> that conforms to the
-conforms to the [[URL]] syntax.
+method</a> MUST be a <a data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                   </p>
                 </dd>
                 <dt>type</dt>


### PR DESCRIPTION
Just removing a duplicate term.