### PR TITLE
Migrate Multikey header definitions from Data Integrity cryptosuites.

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,7 +771,6 @@ then be encoded using the base-58-btc alphabet, according to Section
               </tbody>
             </table>
 
-
             <p>
 The secret key values are expressed using the rules in the table below:
             </p>
@@ -824,20 +823,23 @@ then be encoded using the base-58-btc alphabet, according to Section
                   </td>
                 </tr>
               </tbody>
+
             </table>
+
+            <p class="advisement">
+Developers are advised to not accidentally publish a representation of a secret
+key. Implementations that adhere to this specification will raise errors in the
+event of a Multikey header value that is not in the public key header table
+above, or when reading a Multikey value that is expected to be a public key,
+such as one published in a controller document, that does not start with a known
+public key header.
+            </p>
 
             <p>
 When defining values for use with `publicKeyMultibase` and `secretKeyMultibase`,
 specification authors MAY define additional header values for other key types in
 other specifications and MUST NOT define alternate encodings for key types
 already defined by this specification.
-            </p>
-
-            <p class="advisement">
-Developers are advised to not accidentally publish a representation of a private
-key. Implementations using this specification will raise errors in the event of
-a Multikey header value that is not in the table above, or is not known to
-the implementation to be a public key value.
             </p>
 
           </section>

--- a/index.html
+++ b/index.html
@@ -702,6 +702,22 @@ Multibase encoded value as described in Section [[[#multibase-0]]].
             </dl>
 
             <p>
+The example below expresses an Ed25519 public key using the format defined
+above:
+            </p>
+
+            <pre class="example nohighlight"
+              title="Multikey encoding of a Ed25519 public key">
+{
+  "@context": ["https://w3id.org/security/multikey/v1"],
+  "id": "did:example:123456789abcdefghi#keys-1",
+  "type": "Multikey",
+  "controller": "did:example:123456789abcdefghi",
+  "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
+}
+            </pre>
+
+            <p>
 The public key values are expressed using the rules in the table below:
             </p>
 

--- a/index.html
+++ b/index.html
@@ -2745,7 +2745,108 @@ calculation.
 
     </section>
 
-    <section class="informative">
+    <section class="appendix informative">
+      <h2>Examples</h2>
+
+      <p>
+This section contains more detailed examples of the concepts introduced in
+the specification.
+      </p>
+      <section class="informative">
+        <h2>Multikey Examples</h2>
+
+        <p>
+This section contains various Multikey examples that might be useful for
+developers seeking test values.
+        </p>
+
+          <pre class="example nohighlight"
+            title="A P-256 public key encoded as a Multikey">
+{
+  "id": "https://multikey.example/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://multikey.example/issuer/123",
+  "publicKeyMultibase": "zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+}
+          </pre>
+
+          <pre class="example nohighlight"
+            title="A P-384 public key encoded as a Multikey">
+{
+  "id": "https://multikey.example/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://multikey.example/issuer/123",
+  "publicKeyMultibase": "z82LkvCwHNreneWpsgPEbV3gu1C6NFJEBg4srfJ5gdxEsMGRJ
+    Uz2sG9FE42shbn2xkZJh54"
+}
+          </pre>
+
+          <pre class="example nohighlight"
+            title="An Ed25519 public key encoded as a Multikey">
+{
+  "id": "https://multikey.example/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://multikey.example/issuer/123",
+  "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+}
+          </pre>
+
+          <pre class="example nohighlight"
+            title="A BLS12-381 G2 group public key, encoded as a Multikey">
+{
+  "id": "https://multikey.example/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://multikey.example/issuer/123",
+  "publicKeyMultibase": "zUC7EK3ZakmukHhuncwkbySmomv3FmrkmS36E4Ks5rsb6VQSRpoCrx6
+  Hb8e2Nk6UvJFSdyw9NK1scFXJp21gNNYFjVWNgaqyGnkyhtagagCpQb5B7tagJu3HDbjQ8h
+  5ypoHjwBb"
+}
+          </pre>
+
+          <pre class="example nohighlight"
+               title="Multiple public keys encoded as Multikeys in a controller document">
+{
+  "@context": "https://www.w3.org/ns/controller/v1",
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "https://multikey.example/issuer/123#key-1",
+    "type": "Multikey",
+    "controller": "https://multikey.example/issuer/123",
+    "publicKeyMultibase": "zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+  }, {
+    "id": "https://multikey.example/issuer/123#key-2",
+    "type": "Multikey",
+    "controller": "https://multikey.example/issuer/123",
+    "publicKeyMultibase": "z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+  }, {
+    "id": "https://multikey.example/issuer/123#key-3",
+    "type": "Multikey",
+    "controller": "https://multikey.example/issuer/123",
+    "publicKeyMultibase": "zUC7EK3ZakmukHhuncwkbySmomv3FmrkmS36E4Ks5rsb6VQSRpoCrx6
+    Hb8e2Nk6UvJFSdyw9NK1scFXJp21gNNYFjVWNgaqyGnkyhtagagCpQb5B7tagJu3HDbjQ8h
+    5ypoHjwBb"
+  }],
+  "authentication": [
+    "did:example:123#key-1"
+  ],
+  "assertionMethod": [
+    "did:example:123#key-2"
+    "did:example:123#key-3"
+  ],
+  "capabilityDelegation": [
+    "did:example:123#key-2"
+  ],
+  "capabilityInvocation": [
+    "did:example:123#key-2"
+  ]
+}
+          </pre>
+        </section>
+      </section>
+
+    </section>
+
+    <section class="appendix informative">
       <h2>Revision History</h2>
 
       <p>
@@ -2763,7 +2864,8 @@ Apply wording updates from VC-JOSE-COSE spec.
       </ul>
 
     </section>
-    <section class="informative">
+
+    <section class="appendix informative">
       <h2>Acknowledgements</h2>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -755,6 +755,61 @@ then be encoded using the base-58-btc alphabet, according to Section
               </tbody>
             </table>
 
+
+            <p>
+The secret key values are expressed using the rules in the table below:
+            </p>
+
+            <table class="simple">
+              <thead>
+                <th>Key type</th>
+                <th>Description</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ECDSA 256-bit secret key</td>
+                  <td>
+The Multikey encoding of a P-256 secret key MUST start with the two-byte prefix
+`0x8626` (the varint expression of `0x1306`) followed by the 32-byte
+secret key data. The resulting 34-byte value MUST then be encoded using the
+base-58-btc alphabet, according to Section [[[#multibase-0]]], and then
+prepended with the base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>ECDSA 384-bit secret key</td>
+                  <td>
+The encoding of a P-384 secret key MUST start with the two-byte prefix `0x8726`
+(the varint expression of `0x1307`) followed by the 48-byte secret
+key data. The resulting 50-byte value is then encoded using the base-58-btc
+alphabet, according to Section [[[#multibase-0]]], and then prepended with the
+base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>Ed25519 256-bit secret key</td>
+                  <td>
+The encoding of an Ed25519 secret key MUST start with the two-byte prefix
+`0x8026` (the varint expression of `0x1300`), followed by the 32-byte secret key
+data. The resulting 34-byte value MUST then be encoded using the base-58-btc
+alphabet, according to Section [[[#multibase-0]]], and then prepended with the
+base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>BLS12-381 381-bit secret key</td>
+                  <td>
+The encoding of an BLS12-381 secret key in the G2 group MUST start with
+the two-byte prefix `0x8030` (the varint expression of `0x130a`), followed
+by the 96-byte compressed public key data. The resulting 98-byte value MUST
+then be encoded using the base-58-btc alphabet, according to Section
+[[[#multibase-0]]], and then prepended with the base-58-btc Multibase header
+(`z`).
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
             <p>
 Any other encodings for key types listed in this specification MUST NOT be
 allowed.

--- a/index.html
+++ b/index.html
@@ -827,8 +827,10 @@ then be encoded using the base-58-btc alphabet, according to Section
             </table>
 
             <p>
-Any other encodings for key types listed in this specification MUST NOT be
-allowed.
+When defining values for use with `publicKeyMultibase` and `secretKeyMultibase`,
+specification authors MAY define additional header values for other key types in
+other specifications and MUST NOT define alternate encodings for key types
+already defined by this specification.
             </p>
 
             <p class="advisement">
@@ -837,11 +839,6 @@ key. Implementations using this specification will raise errors in the event of
 a Multikey header value that is not in the table above, or is not known to
 the implementation to be a public key value.
             </p>
-
-            <p>
-Additional header values MAY be defined by other specifications.
-            </p>
-
 
           </section>
 

--- a/index.html
+++ b/index.html
@@ -681,7 +681,7 @@ Multibase value as described in Section [[[#multibase-0]]].
             </p>
 
             <p>
-When specifing a `Multikey`, the object takes the following form:
+When specifying a `Multikey`, the object takes the following form:
             </p>
 
             <dl>
@@ -702,51 +702,75 @@ Multibase encoded value as described in Section [[[#multibase-0]]].
             </dl>
 
             <p>
-An example of a Multikey is provided below:
+The public key values are expressed using the rules in the table below:
             </p>
 
-            <pre class="example nohighlight"
-              title="Multikey encoding of a Ed25519 public key">
-{
-  "@context": ["https://w3id.org/security/multikey/v1"],
-  "id": "did:example:123456789abcdefghi#keys-1",
-  "type": "Multikey",
-  "controller": "did:example:123456789abcdefghi",
-  "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
-}
-            </pre>
+            <table class="simple">
+              <thead>
+                <th>Key type</th>
+                <th>Description</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ECDSA 256-bit public key</td>
+                  <td>
+The Multikey encoding of a P-256 public key MUST start with the two-byte prefix
+`0x8024` (the varint expression of `0x1200`) followed by the 33-byte compressed
+public key data. The resulting 35-byte value MUST then be encoded using the
+base-58-btc alphabet, according to Section [[[#multibase-0]]], and then
+prepended with the base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>ECDSA 384-bit public key</td>
+                  <td>
+The encoding of a P-384 public key MUST start with the two-byte prefix `0x8124`
+(the varint expression of `0x1201`) followed by the 49-byte compressed public
+key data. The resulting 51-byte value is then encoded using the base-58-btc
+alphabet, according to Section [[[#multibase-0]]], and then prepended with the
+base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>Ed25519 256-bit public key</td>
+                  <td>
+The encoding of an Ed25519 public key MUST start with the two-byte prefix
+`0xed01` (the varint expression of `0xed`), followed by the 32-byte public key
+data. The resulting 34-byte value MUST then be encoded using the base-58-btc
+alphabet, according to Section [[[#multibase-0]]], and then prepended with the
+base-58-btc Multibase header (`z`).
+                  </td>
+                </tr>
+                <tr>
+                  <td>BLS12-381 381-bit public key</td>
+                  <td>
+The encoding of an BLS12-381 public key in the G2 group MUST start with
+the two-byte prefix `0xeb01` (the varint expression of `0xeb`), followed
+by the 96-byte compressed public key data. The resulting 98-byte value MUST
+then be encoded using the base-58-btc alphabet, according to Section
+[[[#multibase-0]]], and then prepended with the base-58-btc Multibase header
+(`z`).
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
             <p>
-In the example above, the `publicKeyMultibase` value starts with the letter `z`,
-which is the <a href="#multibase-0">Multibase</a> header that conveys that the
-binary data is base-58-btc-encoded using the Bitcoin base-encoding alphabet. The
-decoded binary data header is `0xed01`, which specifies that the
-remaining data is a 32-byte raw Ed25519 [=public key=].
+Any other encodings for key types listed in this specification MUST NOT be
+allowed.
+            </p>
+
+            <p class="advisement">
+Developers are advised to not accidentally publish a representation of a private
+key. Implementations using this specification will raise errors in the event of
+a Multikey header value that is not in the table above, or is not known to
+the implementation to be a public key value.
             </p>
 
             <p>
-The Multikey data model is also capable of encoding secret keys, whose subtypes
-include <em>symmetric keys</em> and <em>private keys</em>.
+Additional header values MAY be defined by other specifications.
             </p>
 
-            <pre class="example nohighlight"
-              title="Multikey encoding of a Ed25519 secret key">
-{
-  "@context": ["https://w3id.org/security/suites/secrets/v1"],
-  "id": "did:example:123456789abcdefghi#keys-1",
-  "type": "Multikey",
-  "controller": "did:example:123456789abcdefghi",
-  "secretKeyMultibase": "z3u2fprgdREFtGakrHr6zLyTeTEZtivDnYCPZmcSt16EYCER"
-}
-            </pre>
-
-            <p>
-In the example above, the `secretKeyMultibase` value starts with the letter `z`,
-which is the <a href="#multibase-0">Multibase</a> header that conveys that the
-binary data is base-58-btc-encoded using the Bitcoin base-encoding alphabet. The
-decoded binary data header is `0x8026`, which specifies that the
-remaining data is a 32-byte raw Ed25519 private key.
-            </p>
 
           </section>
 

--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@ revocation.
         "https://w3id.org/security/jwk/v1",
         "https://w3id.org/security/data-integrity/v2"
       ]
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "verificationMethod": [{
         "id": <span class="comment">...</span>,
@@ -649,12 +649,12 @@ methods</a> using both properties above is shown below.
         "https://w3id.org/security/jwk/v1",
         "https://w3id.org/security/multikey/v1"
       ]
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "verificationMethod": [{
-        "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+        "id": "https://controller.example/123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
         "type": "JsonWebKey", <span class="comment">// external (property value)</span>
-        "controller": "did:example:123",
+        "controller": "https://controller.example/123",
         "publicKeyJwk": {
           "crv": "Ed25519", <span class="comment">// external (property name)</span>
           "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ", <span class="comment">// external (property name)</span>
@@ -662,7 +662,7 @@ methods</a> using both properties above is shown below.
           "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A" <span class="comment">// external (property name)</span>
         }
       }, {
-        "id": "did:example:123456789abcdefghi#keys-1",
+        "id": "https://controller.example/123456789abcdefghi#keys-1",
         "type": "Multikey", <span class="comment">// external (property value)</span>
         "controller": "did:example:pqrstuvwxyz0987654321",
         "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
@@ -710,9 +710,9 @@ above:
               title="Multikey encoding of a Ed25519 public key">
 {
   "@context": ["https://w3id.org/security/multikey/v1"],
-  "id": "did:example:123456789abcdefghi#keys-1",
+  "id": "https://controller.example/123456789abcdefghi#keys-1",
   "type": "Multikey",
-  "controller": "did:example:123456789abcdefghi",
+  "controller": "https://controller.example/123456789abcdefghi",
   "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
 }
             </pre>
@@ -906,9 +906,9 @@ An example of an object that conforms to `JsonWebKey` is provided below:
 
             <pre class="example nohighlight" title="JSON Web Key encoding of a secp384r1 (P-384) public key">
 {
-  "id": "did:example:123456789abcdefghi#key-1",
+  "id": "https://controller.example/123456789abcdefghi#key-1",
   "type": "JsonWebKey",
-  "controller": "did:example:123456789abcdefghi",
+  "controller": "https://controller.example/123456789abcdefghi",
   "publicKeyJwk": {
       "kid": "key-1",
       "kty": "EC",
@@ -942,9 +942,9 @@ referred to as <em>private keys</em>.
             <pre class="example nohighlight"
               title="JSON Web Key encoding of a secp384r1 (P-384) secret key">
 {
-  "id": "did:example:123456789abcdefghi#key-1",
+  "id": "https://controller.example/123456789abcdefghi#key-1",
   "type": "JsonWebKey",
-  "controller": "did:example:123456789abcdefghi",
+  "controller": "https://controller.example/123456789abcdefghi",
   "secretKeyJwk": {
       "kty": "EC",
       "crv": "P-384",
@@ -995,12 +995,12 @@ is done by dereferencing the URL and searching the resulting resource for a
       "authentication": [
         <span class="comment">// this key is referenced and might be used by</span>
         <span class="comment">// more than one verification relationship</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this key is embedded and may *only* be used for authentication</span>
         {
-          "id": "did:example:123456789abcdefghi#keys-2",
+          "id": "https://controller.example/123456789abcdefghi#keys-2",
           "type": "Multikey", <span class="comment">// external (property value)</span>
-          "controller": "did:example:123456789abcdefghi",
+          "controller": "https://controller.example/123456789abcdefghi",
           "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
         }
       ],
@@ -1079,18 +1079,18 @@ referenced.
         "https://www.w3.org/ns/credentials/v2",
         "https://w3id.org/security/multikey/v1"
       ],
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "authentication": [
         <span class="comment">// this method can be used to authenticate as did:...fghi</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this method is *only* approved for authentication, it may not</span>
         <span class="comment">// be used for any other proof purpose, so its full description is</span>
         <span class="comment">// embedded here rather than using only a reference</span>
         {
-          "id": "did:example:123456789abcdefghi#keys-2",
+          "id": "https://controller.example/123456789abcdefghi#keys-2",
           "type": "Multikey",
-          "controller": "did:example:123456789abcdefghi",
+          "controller": "https://controller.example/123456789abcdefghi",
           "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
         }
       ],
@@ -1162,18 +1162,18 @@ corresponding [=controller document=].
         "https://www.w3.org/ns/credentials/v2",
         "https://w3id.org/security/multikey/v1"
       ],
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "assertionMethod": [
         <span class="comment">// this method can be used to assert statements as did:...fghi</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this method is *only* approved for assertion of statements, it is not</span>
         <span class="comment">// used for any other verification relationship, so its full description is</span>
         <span class="comment">// embedded here rather than using a reference</span>
         {
-          "id": "did:example:123456789abcdefghi#keys-2",
+          "id": "https://controller.example/123456789abcdefghi#keys-2",
           "type": "Multikey", <span class="comment">// external (property value)</span>
-          "controller": "did:example:123456789abcdefghi",
+          "controller": "https://controller.example/123456789abcdefghi",
           "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
         }
       ],
@@ -1213,18 +1213,18 @@ wrap a decryption key for the recipient.
                           containing two verification methods">
     {
       "@context": "https://www.w3.org/ns/did/v1",
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "keyAgreement": [
         <span class="comment">// this method can be used to perform key agreement as did:...fghi</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this method is *only* approved for key agreement usage, it will not</span>
         <span class="comment">// be used for any other verification relationship, so its full description is</span>
         <span class="comment">// embedded here rather than using only a reference</span>
         {
-          "id": "did:example:123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
+          "id": "https://controller.example/123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
           "type": "X25519KeyAgreementKey2019", <span class="comment">// external (property value)</span>
-          "controller": "did:example:123",
+          "controller": "https://controller.example/123",
           "publicKeyMultibase": "z6LSn6p3HRxx1ZZk1dT9VwcfTBCYgtNWdzdDMKPZjShLNWG7"
         }
       ],
@@ -1280,18 +1280,18 @@ protected resource.
         "https://www.w3.org/ns/did/v1",
         "https://w3id.org/security/multikey/v1"
       ],
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "capabilityInvocation": [
         <span class="comment">// this method can be used to invoke capabilities as did:...fghi</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this method is *only* approved for capability invocation usage, it will not</span>
         <span class="comment">// be used for any other verification relationship, so its full description is</span>
         <span class="comment">// embedded here rather than using only a reference</span>
         {
-        "id": "did:example:123456789abcdefghi#keys-2",
+        "id": "https://controller.example/123456789abcdefghi#keys-2",
         "type": "Multikey", <span class="comment">// external (property value)</span>
-        "controller": "did:example:123456789abcdefghi",
+        "controller": "https://controller.example/123456789abcdefghi",
         "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
         }
       ],
@@ -1338,18 +1338,18 @@ example described in [[[#capability-invocation]]].
         "https://www.w3.org/ns/did/v1",
         "https://w3id.org/security/multikey/v1"
       ],
-      "id": "did:example:123456789abcdefghi",
+      "id": "https://controller.example/123456789abcdefghi",
       <span class="comment">...</span>
       "capabilityDelegation": [
         <span class="comment">// this method can be used to perform capability delegation as did:...fghi</span>
-        "did:example:123456789abcdefghi#keys-1",
+        "https://controller.example/123456789abcdefghi#keys-1",
         <span class="comment">// this method is *only* approved for granting capabilities; it will not</span>
         <span class="comment">// be used for any other verification relationship, so its full description is</span>
         <span class="comment">// embedded here rather than using only a reference</span>
         {
-        "id": "did:example:123456789abcdefghi#keys-2",
+        "id": "https://controller.example/123456789abcdefghi#keys-2",
         "type": "Multikey", <span class="comment">// external (property value)</span>
-        "controller": "did:example:123456789abcdefghi",
+        "controller": "https://controller.example/123456789abcdefghi",
         "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
         }
       ],
@@ -2807,7 +2807,7 @@ developers seeking test values.
                title="Multiple public keys encoded as Multikeys in a controller document">
 {
   "@context": "https://www.w3.org/ns/controller/v1",
-  "id": "did:example:123",
+  "id": "https://controller.example/123",
   "verificationMethod": [{
     "id": "https://multikey.example/issuer/123#key-1",
     "type": "Multikey",
@@ -2827,17 +2827,17 @@ developers seeking test values.
     5ypoHjwBb"
   }],
   "authentication": [
-    "did:example:123#key-1"
+    "https://controller.example/123#key-1"
   ],
   "assertionMethod": [
-    "did:example:123#key-2"
-    "did:example:123#key-3"
+    "https://controller.example/123#key-2"
+    "https://controller.example/123#key-3"
   ],
   "capabilityDelegation": [
-    "did:example:123#key-2"
+    "https://controller.example/123#key-2"
   ],
   "capabilityInvocation": [
-    "did:example:123#key-2"
+    "https://controller.example/123#key-2"
   ]
 }
           </pre>


### PR DESCRIPTION
This PR is an attempt to address issue #27 by moving the Multikey header definitions from the various cryptosuite specifications to this specification so they are easier to find for developers.