### PR TITLE
Specify that controller overrides subject control.

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,6 +651,9 @@ contain [=verification relationships=] that explicitly permit the use of
 certain [=verification methods=] for specific purposes. If the `controller`
 property is not present, the value expressed by the `id` property MUST be
 treated as if it were also set as the value of the `controller` property.
+If the `controller` property is present, it establishes one or more
+[=controllers=] that have change control over the document which MAY include
+the [=subject=] specified via the `id` attribute.
               </dd>
             </dl>
 


### PR DESCRIPTION
This PR is an attempt to address issue #33 by specifying that the controller overrides subject control, but the subject may be listed in the list of controllers.