### PR TITLE
Context section consistency issue 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -2285,7 +2285,8 @@ the referenced files to be modified.
 The terms defined in this specification are also part of the 
 <a href="https://w3id.org/security">https://w3id.org/security#</a> RDF
 <a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]].
-That is, for any `TERM`, the relevant URL is of the form `https://w3id.org/security#TERM`.
+For any `TERM`, the relevant URL is of the form `https://w3id.org/security#TERMmethod`,
+except (for historical reasons) for the term `assertion`, whose URL is `https://w3id.org/security#assertion`.)
 Implementations that use RDF processing relying on this specification MUST use these URLs.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -338,14 +338,14 @@ prohibiting and/or deprecating the use of others.
         <p>
 A <dfn>conforming controller document</dfn> is any concrete expression of the
 data model that follows the relevant normative requirements in Sections
-[[[#data-model]]] and [[[#contexts-and-vocabularies]]].
+[[[#data-model]]] and [[[#vocabulary]]].
         </p>
 
         <p>
 A <dfn>conforming verification method</dfn> is any concrete expression of the
 data model that follows the relevant normative requirements in Sections
 [[[#verification-methods]]] and
-[[[#contexts-and-vocabularies]]].
+[[[#vocabulary]]].
         </p>
 
         <p>
@@ -2273,7 +2273,7 @@ the `proofPurpose` property in the proof. See Section
     </section>
 
     <section>
-      <h2>Contexts and Vocabularies</h2>
+      <h2>Vocabulary</h2>
 
       <p class="issue" title="(AT RISK) Hash values might change during Candidate Recommendation">
 This section lists cryptographic hash values that might change during the

--- a/index.html
+++ b/index.html
@@ -2286,7 +2286,7 @@ The terms defined in this specification are also part of the
 <a href="https://w3id.org/security">https://w3id.org/security#</a> RDF
 <a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]].
 For any `TERM`, the relevant URL is of the form `https://w3id.org/security#TERMmethod`,
-except (for historical reasons) for the term `assertion`, whose URL is `https://w3id.org/security#assertion`.
+except (for historical reasons) for the term `authentication`, whose URL is `https://w3id.org/security#authentication`.
 Implementations that use RDF processing relying on this specification MUST use these URLs.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -2286,7 +2286,7 @@ The terms defined in this specification are also part of the
 <a href="https://w3id.org/security">https://w3id.org/security#</a> RDF
 <a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]].
 For any `TERM`, the relevant URL is of the form `https://w3id.org/security#TERMmethod`,
-except (for historical reasons) for the term `assertion`, whose URL is `https://w3id.org/security#assertion`.)
+except (for historical reasons) for the term `assertion`, whose URL is `https://w3id.org/security#assertion`.
 Implementations that use RDF processing relying on this specification MUST use these URLs.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -2280,173 +2280,86 @@ This section lists cryptographic hash values that might change during the
 Candidate Recommendation phase based on implementer feedback that requires
 the referenced files to be modified.
       </p>
-      <p>
-Implementations that perform JSON-LD processing MUST treat the following
-JSON-LD context URLs as already resolved, where the resolved document matches
-the corresponding hash values below:
-      </p>
-
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>URL, Media Type, and Content Digest</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/data-integrity/v2 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/data-integrity/v2"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/multikey/v1 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/multikey/v1"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/jwk/v1 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/jwk/v1"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
 
       <p>
-The security vocabulary terms that the JSON-LD contexts listed above resolve
-to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
-namespace. That is, all security terms in this vocabulary are of the form
-`https://w3id.org/security#TERM`, where `TERM` is the name of a term.
+The terms defined in this specification are also part of the 
+<a href="https://w3id.org/security">https://w3id.org/security#</a> RDF
+<a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]].
+That is, for any `TERM`, the relevant URL is of the form `https://w3id.org/security#TERM`.
+Implementations that use RDF processing relying on this specification MUST use these URLs.
       </p>
 
-      <p>
-Implementations that perform RDF processing MUST treat the following
-JSON-LD vocabulary URL as already resolved, where the resolved document matches
-the corresponding hash values below.
-      </p>
+<p>
+  When dereferencing the
+  <a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
+  the media type of the data that is returned depends on HTTP content negotiation. These are as follows:
+</p>
 
-      <p>
-When dereferencing the
-<a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
-the data returned depends on HTTP content negotiation. These are as follows:
-      </p>
+<table class="simple">
+  <thead>
+    <tr>
+      <th>Media Type</th>
+      <th>Description and Hash</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        application/ld+json
+      </td>
+      <td>
+        The vocabulary in JSON-LD format [[?JSON-LD11]].<br><br>
 
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>URL, Media Type, and Content Digest</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong><code><span class="vc-hash"
+        <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
 data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld"
 data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (text/turtle)<br>
-<strong>SHA2-256 Digest:</strong><code><span class="vc-hash"
+      </td>
+    </tr>
+    <tr>
+      <td>
+        text/turtle
+      </td>
+      <td>
+        The vocabulary in Turtle format [[?TURTLE]].<br><br>
+
+        <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
 data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.ttl"
 data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (text/html)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
+      </td>
+    </tr>
+    <tr>
+      <td>
+        text/html
+      </td>
+      <td>
+        The vocabulary in HTML+RDFa Format [[?HTML-RDFA]].<br><br>
+
+
+        <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
 data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html"
 data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-      <p>
-It is possible to confirm the digests listed above by running the following
-command from a modern Unix command interface line:
-`curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -sha256`.
+<p>
+  It is possible to confirm the cryptographic digests listed above by running
+  a command like the following (replacing `&lt;MEDIA_TYPE>` and `&lt;DOCUMENT_URL>`
+  with the appropriate values) through a modern UNIX-like OS command line interface:
+  `curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -sha256`
+</p>
+
+
+      <p class="note">
+Applications or specifications that are based on JSON-LD processing should define mappings to the 
+vocabulary URLs using JSON-LD contexts. For example, for the terms defined in this
+specification, such mappings are part of the `https://w3id.org/security/data-integrity/v2` context, 
+defined by the [[[?VC-DATA-INTEGRITY]]] specification, or the `https://www.w3.org/ns/did/v1` context, 
+defined by the [[[?DID-CORE]]] specification.
       </p>
 
-      <p>
-Authors of application-specific vocabularies and specifications SHOULD ensure
-that their JSON-LD context and vocabulary files are permanently cacheable
-using the approaches to caching described above or a functionally equivalent
-mechanism.
-      </p>
-
-      <p>
-Implementations MAY load application-specific JSON-LD context files from the
-network during development, but SHOULD permanently cache JSON-LD context files
-used in [=conforming documents=] in production settings to increase their
-security and privacy characteristics. Caching goals MAY be achieved through
-approaches such as those described above or functionally equivalent mechanisms.
-      </p>
-      <p>
-Some applications, such as digital wallets, that are capable of holding arbitrary
-verifiable credentials or other data-integrity-protected documents, from
-any issuer and using any contexts, might need to be able to load externally
-linked resources, such as JSON-LD context files, in production settings. This is
-expected to increase user choice, scalability, and decentralized upgrades in the
-ecosystem over time. Authors of such applications are advised to read the
-security and privacy sections of this document for further considerations.
-      </p>
-
-      <p>
-For further information regarding processing of JSON-LD contexts and
-vocabularies, see <a data-cite="?VC-DATA-MODEL-2.0#base-context">Verifiable
-Credentials v2.0: Base Context</a> and <a data-cite="?VC-DATA-MODEL-2.0#vocabularies">
-Verifiable Credentials v2.0: Vocabularies</a>.
-      </p>
-
-      <section>
-        <h3>Context Injection</h3>
-
-        <p>
-The `@context` property is used to ensure that implementations are using the
-same semantics when terms in this specification are processed. For example, this
-can be important when properties like `type` are processed and its value, such
-as `DataIntegrityProof`, are used.
-        </p>
-
-        <p>
-If an `@context` property is not provided in a document that is being secured or
-verified, or the Data Integrity terms used in the document are not mapped by
-existing values in the `@context` property, implementations MUST inject or add
-an `@context` property with a value of
-`https://w3id.org/security/data-integrity/v2`.
-        </p>
-
-        <p>
-Context injection is expected to be unnecessary sometimes, such as when the Verifiable
-Credential Data Model v2.0 context (`https://www.w3.org/ns/credentials/v2`)
-exists as a value in the `@context` property, as that context maps all of the
-necessary Data Integrity terms that were previously mapped by
-`https://w3id.org/security/data-integrity/v2`.
-        </p>
-      </section>
-
+ 
       <section>
         <h3>Datatypes</h3>
 


### PR DESCRIPTION
This PR reflects my proposed (and now favorite) solution to solve #10, the one in https://github.com/w3c/controller-document/issues/10#issuecomment-2293364035. What it does is that it removes all texts on JSON-LD and contexts from the core, normative text.

The reason I actually favor this is that the controller document specification is thought to be generic; even if used for Linked Data, that does not mean using it through JSON-LD. The sections on, say, context injection is not relevant if my application uses linked data in, say, Turtle or a SPARQL Database (that section has also been removed).

What remains is the reference to the vocabulary that defines the term URLs, to be used with Linked Data, and that part of the section is in sync with its counterpart in the DI spec. No inconsistency anymore. There is a (non-normative) note referring to context files that may use this vocabulary, referring (as an example, i.e., non-normatively) to the DID and DI specifications. 

Hopefully this is acceptable for everyone to close issue #10.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/43.html" title="Last updated on Aug 20, 2024, 3:26 PM UTC (4de867f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/43/b740988...4de867f.html" title="Last updated on Aug 20, 2024, 3:26 PM UTC (4de867f)">Diff</a>