### PR TITLE
Changed valid to conforming for controller and vm documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -2156,7 +2156,7 @@ convey an error type of
 <a href="#INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID</a>.
           </li>
           <li>
-If <var>controllerDocument</var> is not a valid [=controller document=],
+If <var>controllerDocument</var> is not a [=conforming controller document=],
 an error MUST be raised and SHOULD
 convey an error type of
 <a href="#INVALID_CONTROLLER_DOCUMENT">INVALID_CONTROLLER_DOCUMENT</a>.
@@ -2167,7 +2167,7 @@ Let <var>verificationMethod</var> be the result of dereferencing the
 rules of the media type of the <var>controllerDocument</var>.
           </li>
           <li>
-If <var>verificationMethod</var> is not a valid [=verification method=],
+If <var>verificationMethod</var> is not a [=conforming verification method=],
 an error MUST be raised and SHOULD convey an error type of
 <a href="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
           </li>


### PR DESCRIPTION
This addresses issue #35.

There are 6 other uses of the word valid in the spec, I reviewed them and they make sense to me. Defining what they mean by valid in the context they are used. Someone else may want to just double check this though.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/controller-document/pull/44.html" title="Last updated on Aug 20, 2024, 12:37 PM UTC (e32083b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/44/b740988...wip-abramson:e32083b.html" title="Last updated on Aug 20, 2024, 12:37 PM UTC (e32083b)">Diff</a>