### PR TITLE
Note that controllers do not need to be single individuals.

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,9 +691,9 @@ by the [=subject=].
             </pre>
 
             <p>
-While the identifier used for a [=controller=] is unique, that uniqueness does
-not imply that a single individual is always the controller, nor does it imply
-that the controller might not be associated by multiple identifiers. A
+While the identifier used for a [=controller=] is unambiguous, that does
+not imply that a single individual is always the controller, nor
+that the controller only has a single identifier. A
 [=controller=] might be a single individual, or a collection of individuals,
 such as a corporation. A [=controller=] might also use multiple identifiers
 to refer to itself, for purposes such as privacy or delineating operational

--- a/index.html
+++ b/index.html
@@ -660,25 +660,24 @@ A [=controller=] is an entity that is authorized to make changes to a
             <dl>
               <dt>controller</dt>
               <dd>
-The `controller` property is OPTIONAL. If present, its value MUST
-be a <a data-cite="INFRA#string">string</a> or a <a
-data-cite="INFRA#ordered-set">set</a> of <a
-data-cite="INFRA#string">strings</a>, each of which conforms to the rules in
-the [[[URL]]]. The corresponding [=controller document=](s) SHOULD
-contain [=verification relationships=] that explicitly permit the use of
-certain [=verification methods=] for specific purposes. If the `controller`
-property is not present, the value expressed by the `id` property MUST be
-treated as if it were also set as the value of the `controller` property.
+The `controller` property is OPTIONAL. If present, its value MUST be a
+<a data-cite="INFRA#string">string</a> or a
+<a data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the rules
+in the [[[URL]]]. The corresponding [=controller document=](s) SHOULD contain
+[=verification relationships=] that explicitly permit the use of certain
+[=verification methods=] for specific purposes. If the `controller` property is
+not present, the value expressed by the `id` property MUST be treated as if it
+were also set as the value of the `controller` property.
               </dd>
             </dl>
 
             <p>
-When a `controller` property is present in a [=controller document=], its
-value expresses one or more identifiers. Any [=verification methods=] contained
-in the [=controller documents=] for those identifiers SHOULD
-be accepted as authoritative, such that proofs that satisfy those
-[=verification methods=] are considered equivalent to proofs provided
-by the [=subject=].
+When a `controller` property is present in a [=controller document=], its value
+expresses one or more identifiers. Any [=verification methods=] contained in the
+[=controller documents=] for those identifiers SHOULD be accepted as
+authoritative, such that proofs that satisfy those [=verification methods=] are
+considered equivalent to proofs provided by the [=subject=].
             </p>
 
             <pre class="example nohighlight"
@@ -691,26 +690,25 @@ by the [=subject=].
             </pre>
 
             <p>
-While the identifier used for a [=controller=] is unambiguous, that does
-not imply that a single entity is always the controller, nor
-that the controller only has a single identifier. A
-[=controller=] might be a single entity, or a collection of entities,
-such as a corporation. A [=controller=] might also use multiple identifiers
-to refer to itself, for purposes such as privacy or delineating operational
-boundaries within an organization. Similarly, a [=controller=] might control
-many [=verification methods=] and so no assumptions are to be made about
-a [=controller=] being a single entity nor only controlling a single
-[=verification method=].
+While the identifier used for a [=controller=] is unambiguous, that does not
+imply that a single entity is always the controller, nor that the controller
+only has a single identifier. A [=controller=] might be a single entity, or a
+collection of entities, such as a corporation. A [=controller=] might also use
+multiple identifiers to refer to itself, for purposes such as privacy or
+delineating operational boundaries within an organization. Similarly, a
+[=controller=] might control many [=verification methods=] and so no assumptions
+are to be made about a [=controller=] being a single entity nor only controlling
+a single [=verification method=].
             </p>
 
             <p class="note" title="Authorization vs authentication">
-Note that authorization provided by the value of `controller` is
-separate from authentication as described in Section [[[#authentication]]].
-This is particularly important for key recovery in the cases of cryptographic key
-loss, where the [=subject=] no longer has access to their keys, or cryptographic
-key compromise, where the [=controller=]'s trusted third parties need to
-override malicious activity by an attacker. See [[[#security-considerations]]]
-for information related to threat models and attack vectors.
+Note that authorization provided by the value of `controller` is separate from
+authentication as described in Section [[[#authentication]]]. This is
+particularly important for key recovery in the cases of cryptographic key loss,
+where the [=subject=] no longer has access to their keys, or cryptographic key
+compromise, where the [=controller=]'s trusted third parties need to override
+malicious activity by an attacker. See [[[#security-considerations]]] for
+information related to threat models and attack vectors.
             </p>
           </section>
 

--- a/index.html
+++ b/index.html
@@ -692,14 +692,14 @@ by the [=subject=].
 
             <p>
 While the identifier used for a [=controller=] is unambiguous, that does
-not imply that a single individual is always the controller, nor
+not imply that a single entity is always the controller, nor
 that the controller only has a single identifier. A
-[=controller=] might be a single individual, or a collection of individuals,
+[=controller=] might be a single entity, or a collection of entities,
 such as a corporation. A [=controller=] might also use multiple identifiers
 to refer to itself, for purposes such as privacy or delineating operational
 boundaries within an organization. Similarly, a [=controller=] might control
 many [=verification methods=] and so no assumptions are to be made about
-a [=controller=] being a single individual nor only controlling a single
+a [=controller=] being a single entity nor only controlling a single
 [=verification method=].
             </p>
 

--- a/index.html
+++ b/index.html
@@ -690,6 +690,19 @@ by the [=subject=].
 }
             </pre>
 
+            <p>
+While the identifier used for a [=controller=] is unique, that uniqueness does
+not imply that a single individual is always the controller, nor does it imply
+that the controller might not be associated by multiple identifiers. A
+[=controller=] might be a single individual, or a collection of individuals,
+such as a corporation. A [=controller=] might also use multiple identifiers
+to refer to itself, for purposes such as privacy or delineating operational
+boundaries within an organization. Similarly, a [=controller=] might control
+many [=verification methods=] and so no assumptions are to be made about
+a [=controller=] being a single individual nor only controlling a single
+[=verification method=].
+            </p>
+
             <p class="note" title="Authorization vs authentication">
 Note that authorization provided by the value of `controller` is
 separate from authentication as described in Section [[[#authentication]]].


### PR DESCRIPTION
This PR is an attempt to address issue #45 by noting that no assumptions are to be made about a controller being a single individual nor only controlling a single verification method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/83.html" title="Last updated on Sep 6, 2024, 9:03 PM UTC (0204b57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/83/87532e4...0204b57.html" title="Last updated on Sep 6, 2024, 9:03 PM UTC (0204b57)">Diff</a>