### PR TITLE
Remove normative text in informative section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,9 +311,9 @@ public cryptographic keys.
       <p>
 A [=controller document=] is a set of data that specifies one or more
 relationships between a [=controller=] and a set of data, such as a set of
-public cryptographic keys. The [=controller document=] SHOULD
-contain [=verification relationships=] that explicitly permit the use of
-certain [=verification methods=] for specific purposes.
+public cryptographic keys. The [=controller document=] contains [=verification
+relationships=] that explicitly permit the use of certain [=verification
+methods=] for specific purposes.
       </p>
       <p>
 It is expected that other specifications, such as [[[?DID-CORE]]], will profile


### PR DESCRIPTION
This PR is an attempt to address issue #46 by removing normative language from an informative section.

This PR specifically does not make the Terminology section normative since the terminology section does not contain any normative language.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/84.html" title="Last updated on Sep 6, 2024, 9:08 PM UTC (0b8589a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/84/deba49a...0b8589a.html" title="Last updated on Sep 6, 2024, 9:08 PM UTC (0b8589a)">Diff</a>