### PR TITLE
Add column to definition of controller document properties.

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,11 +559,10 @@ A <a data-cite="INFRA#ordered-set">set</a> of
                 <td>`authentication`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
-data-cite="INFRA#ordered-map">maps</a> or a a <a
-data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
-syntax.
+A <a data-cite="INFRA#ordered-set">set</a> of <a
+data-cite="INFRA#string">strings</a>, each of which conforms to
+the URL syntax, or a <a data-cite="INFRA#ordered-set">set</a> of
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
                 <td style="white-space: nowrap;">[[[#authentication]]]</td>
               </tr>
@@ -571,11 +570,10 @@ syntax.
                 <td>`assertionMethod`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
-data-cite="INFRA#ordered-map">maps</a> or a a <a
-data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
-syntax.
+A <a data-cite="INFRA#ordered-set">set</a> of <a
+data-cite="INFRA#string">strings</a>, each of which conforms to
+the URL syntax, or a <a data-cite="INFRA#ordered-set">set</a> of
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
                 <td style="white-space: nowrap;">[[[#assertion]]]</td>
               </tr>
@@ -583,11 +581,10 @@ syntax.
                 <td>`keyAgreement`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
-data-cite="INFRA#ordered-map">maps</a> or a a <a
-data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
-syntax.
+A <a data-cite="INFRA#ordered-set">set</a> of <a
+data-cite="INFRA#string">strings</a>, each of which conforms to
+the URL syntax, or a <a data-cite="INFRA#ordered-set">set</a> of
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
                 <td style="white-space: nowrap;">[[[#key-agreement]]]</td>
               </tr>
@@ -595,11 +592,10 @@ syntax.
                 <td>`capabilityInvocation`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
-data-cite="INFRA#ordered-map">maps</a> or a a <a
-data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
-syntax.
+A <a data-cite="INFRA#ordered-set">set</a> of <a
+data-cite="INFRA#string">strings</a>, each of which conforms to
+the URL syntax, or a <a data-cite="INFRA#ordered-set">set</a> of
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
                 <td style="white-space: nowrap;">[[[#capability-invocation]]]</td>
               </tr>
@@ -607,11 +603,10 @@ syntax.
                 <td>`capabilityDelegation`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
-data-cite="INFRA#ordered-map">maps</a> or a a <a
-data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
-syntax.
+A <a data-cite="INFRA#ordered-set">set</a> of <a
+data-cite="INFRA#string">strings</a>, each of which conforms to
+the URL syntax, or a <a data-cite="INFRA#ordered-set">set</a> of
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
                 <td style="white-space: nowrap;">[[[#capability-delegation]]]</td>
               </tr>

--- a/index.html
+++ b/index.html
@@ -513,6 +513,7 @@ definitions and more detailed descriptions of each property.
                 <th>Property</th>
                 <th>Required?</th>
                 <th>Value constraints</th>
+                <th style="white-space: nowrap;">Definition</th>
               </tr>
             </thead>
             <tbody>
@@ -520,18 +521,9 @@ definitions and more detailed descriptions of each property.
                 <td>`id`</td>
                 <td>yes</td>
                 <td>
-A <a data-cite="INFRA#string">string</a> that conforms to the URL syntax
-defined in Section [[[#subjects]]].
+A <a data-cite="INFRA#string">string</a> that conforms to the URL syntax.
                 </td>
-              </tr>
-              <tr>
-                <td>`alsoKnownAs`</td>
-                <td>no</td>
-                <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]] as defined in Section [[[#also-known-as]]].
-                </td>
+                <td style="white-space: nowrap;">[[[#subjects]]]</td>
               </tr>
               <tr>
                 <td>`controller`</td>
@@ -539,78 +531,89 @@ defined in the [[[URL]]] as defined in Section [[[#also-known-as]]].
                 <td>
 A <a data-cite="INFRA#string">string</a> or a
 <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]] as defined in Section [[[#controllers]]].
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#controllers]]]</td>
+              </tr>
+              <tr>
+                <td>`alsoKnownAs`</td>
+                <td>no</td>
+                <td>
+A <a data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
+                </td>
+                <td style="white-space: nowrap;">[[[#also-known-as]]]</td>
               </tr>
               <tr>
                 <td>`verificationMethod`</td>
                 <td>no</td>
                 <td>
 A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#verification-methods]]].
+[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>.
                 </td>
+                <td style="white-space: nowrap;">[[[#verification-methods]]]</td>
               </tr>
               <tr>
                 <td>`authentication`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#authentication]]]; or a
-a <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]].
+A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
+data-cite="INFRA#ordered-map">maps</a> or a a <a
+data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#authentication]]]</td>
               </tr>
               <tr>
                 <td>`assertionMethod`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#assertion]]]; or a
-a <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]].
+A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
+data-cite="INFRA#ordered-map">maps</a> or a a <a
+data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#assertion]]]</td>
               </tr>
               <tr>
                 <td>`keyAgreement`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#key-agreement]]]; or a
-a <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]].
+A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
+data-cite="INFRA#ordered-map">maps</a> or a a <a
+data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#key-agreement]]]</td>
               </tr>
               <tr>
                 <td>`capabilityInvocation`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#capability-invocation]]]; or a
-a <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]].
+A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
+data-cite="INFRA#ordered-map">maps</a> or a a <a
+data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#capability-invocation]]]</td>
               </tr>
               <tr>
                 <td>`capabilityDelegation`</td>
                 <td>no</td>
                 <td>
-A <a data-cite="INFRA#ordered-set">set</a> of
-[=verification method=] <a data-cite="INFRA#ordered-map">maps</a>, each of which
-conforms to the rules in Section [[[#capability-delegation]]]; or a
-a <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL syntax
-defined in the [[[URL]]].
+A <a data-cite="INFRA#ordered-set">set</a> of [=verification method=] <a
+data-cite="INFRA#ordered-map">maps</a> or a a <a
+data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>, each of which conforms to the URL
+syntax.
                 </td>
+                <td style="white-space: nowrap;">[[[#capability-delegation]]]</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
This PR is an attempt to address issue #53 by adding a definition reference column to the Controller Documents property table.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/85.html" title="Last updated on Sep 6, 2024, 9:18 PM UTC (278dde4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/85/2b1587c...278dde4.html" title="Last updated on Sep 6, 2024, 9:18 PM UTC (278dde4)">Diff</a>