### PR TITLE
Clarify representation of cryptographic hash length.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1741,10 +1741,10 @@ Multibase header. Any algorithm with equivalent output MAY be used.
 
           <p>
 A Multihash value starts with a binary header, which includes 1) an identifier
-for the specific cryptographic hash algorithm, 2) the length of the
-cryptographic hash, and 3) the value of the cryptographic hash. The normative
-Multihash header values defined by this specification, and their associated
-output sizes and associated specifications, are provided below:
+for the specific cryptographic hashing algorithm, 2) a cryptographic digest size
+in bytes, and 3) the value of the cryptographic digest. The normative Multihash
+header values defined by this specification, and their associated output sizes
+and associated specifications, are provided below:
           </p>
 
           <table class="simple">
@@ -1795,17 +1795,18 @@ guaranteed between implementations.
 
           <p>
 To encode to a Multihash value, an implementation MUST concatenate the
-associated Multihash header, the cryptographic hash length, and the
-cryptographic hash value, in that order.
+associated Multihash header (encoded as a varint), the cryptographic digest
+length in bytes (encoded as a varint), and the cryptographic digest value, in
+that order.
           </p>
 
           <p>
 To decode a Multihash value, an implementation MUST 1) remove the prepended
-Multihash header value, which identifies the type of cryptographic hashing
-algorithm, 2) remove the output length, and 3) extract the raw cryptographic
-hash value which MUST match the expected output length associated with the
-Multihash header as well as the output length provided in the Multihash
-value itself.
+Multihash header value, which identifies the type of cryptographic hash
+algorithm, 2) remove the cryptogrphic digest length in bytes, and 3) extract the
+raw cryptographic digest value which MUST match the expected output length
+associated with the Multihash header as well as the output length provided in
+the Multihash value itself.
           </p>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1741,10 +1741,10 @@ Multibase header. Any algorithm with equivalent output MAY be used.
 
           <p>
 A Multihash value starts with a binary header, which includes 1) an identifier
-for the specific cryptographic hashing algorithm, 2) a cryptographic digest size
-in bytes, and 3) the value of the cryptographic digest. The normative Multihash
-header values defined by this specification, and their associated output sizes
-and associated specifications, are provided below:
+for the specific cryptographic hashing algorithm, 2) a cryptographic digest
+length in bytes, and 3) the value of the cryptographic digest. The normative
+Multihash header values defined by this specification, and their associated
+output sizes and associated specifications, are provided below:
           </p>
 
           <table class="simple">

--- a/index.html
+++ b/index.html
@@ -1803,7 +1803,7 @@ that order.
           <p>
 To decode a Multihash value, an implementation MUST 1) remove the prepended
 Multihash header value, which identifies the type of cryptographic hash
-algorithm, 2) remove the cryptogrphic digest length in bytes, and 3) extract the
+algorithm, 2) remove the cryptographic digest length in bytes, and 3) extract the
 raw cryptographic digest value which MUST match the expected output length
 associated with the Multihash header as well as the output length provided in
 the Multihash value itself.

--- a/index.html
+++ b/index.html
@@ -1802,9 +1802,9 @@ that order.
 
           <p>
 To decode a Multihash value, an implementation MUST 1) remove the prepended
-Multihash header value, which identifies the type of cryptographic hash
-algorithm, 2) remove the cryptographic digest length in bytes, and 3) extract the
-raw cryptographic digest value which MUST match the expected output length
+Multihash header value, which identifies the type of cryptographic hashing
+algorithm, 2) remove the cryptographic digest length in bytes, and 3) extract
+the raw cryptographic digest value which MUST match the expected output length
 associated with the Multihash header as well as the output length provided in
 the Multihash value itself.
           </p>


### PR DESCRIPTION
This PR is an attempt to address issue #65 by clarifying the cryptographic hash length and encoding.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/88.html" title="Last updated on Sep 6, 2024, 9:38 PM UTC (543f0e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/88/2b1587c...543f0e0.html" title="Last updated on Sep 6, 2024, 9:38 PM UTC (543f0e0)">Diff</a>