### PR TITLE
Alternative version of the "context and vocabulary" section

### DIFF
--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -52,6 +52,10 @@
         "publicKeyMultibase": {
           "@id": "https://w3id.org/security#publicKeyMultibase",
           "@type": "https://w3id.org/security#multibase"
+        },
+        "secretKeyMultibase": {
+          "@id": "https://w3id.org/security#secretKeyMultibase",
+          "@type": "https://w3id.org/security#multibase"
         }
       }
     },
@@ -63,6 +67,10 @@
         "type": "@type",
         "publicKeyJwk": {
           "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        },
+        "secretKeyJwk": {
+          "@id": "https://w3id.org/security#secretKeyJwk",
           "@type": "@json"
         }
       }

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -52,10 +52,6 @@
         "publicKeyMultibase": {
           "@id": "https://w3id.org/security#publicKeyMultibase",
           "@type": "https://w3id.org/security#multibase"
-        },
-        "secretKeyMultibase": {
-          "@id": "https://w3id.org/security#secretKeyMultibase",
-          "@type": "https://w3id.org/security#multibase"
         }
       }
     },
@@ -67,10 +63,6 @@
         "type": "@type",
         "publicKeyJwk": {
           "@id": "https://w3id.org/security#publicKeyJwk",
-          "@type": "@json"
-        },
-        "secretKeyJwk": {
-          "@id": "https://w3id.org/security#secretKeyJwk",
           "@type": "@json"
         }
       }

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -43,26 +43,58 @@
       "@type": "@id",
       "@container": "@set"
     },
-    "Multikey": {
+   "Multikey": {
       "@id": "https://w3id.org/security#Multikey",
       "@context": {
         "@protected": true,
         "id": "@id",
         "type": "@type",
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
         "publicKeyMultibase": {
           "@id": "https://w3id.org/security#publicKeyMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "secretKeyMultibase": {
+          "@id": "https://w3id.org/security#secretKeyMultibase",
           "@type": "https://w3id.org/security#multibase"
         }
       }
     },
-    "JsonWebKey": {
+   "JsonWebKey": {
       "@id": "https://w3id.org/security#JsonWebKey",
       "@context": {
         "@protected": true,
         "id": "@id",
         "type": "@type",
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
         "publicKeyJwk": {
           "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        },
+        "secretKeyJwk": {
+          "@id": "https://w3id.org/security#secretKeyJwk",
           "@type": "@json"
         }
       }

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -1,0 +1,79 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+
+    "alsoKnownAs": {
+      "@id": "https://w3id.org/security#alsoKnownAs",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "assertionMethod": {
+      "@id": "https://w3id.org/security#assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "https://w3id.org/security#authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityDelegation": {
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "controller": {
+      "@id": "https://w3id.org/security#controller",
+      "@type": "@id"
+    },
+    "keyAgreement": {
+      "@id": "https://w3id.org/security#keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "verificationMethod": {
+      "@id": "https://w3id.org/security#verificationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "Multikey": {
+      "@id": "https://w3id.org/security#Multikey",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "publicKeyMultibase": {
+          "@id": "https://w3id.org/security#publicKeyMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "secretKeyMultibase": {
+          "@id": "https://w3id.org/security#secretKeyMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+    "JsonWebKey": {
+      "@id": "https://w3id.org/security#JsonWebKey",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "publicKeyJwk": {
+          "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        },
+        "secretKeyJwk": {
+          "@id": "https://w3id.org/security#secretKeyJwk",
+          "@type": "@json"
+        }
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1171,7 +1171,6 @@ Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their [=public keys=] use the value of `kid` as
 their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
 the JWK Thumbprint [[RFC7638]] using the SHA-256 (SHA2-256) hash function of the [=public key=].
-See the first key in
 [[[#example-various-verification-method-types]]] for an example of a
 public key with a compound key identifier.
                 </p>

--- a/index.html
+++ b/index.html
@@ -1170,6 +1170,7 @@ in the <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their [=public keys=] use the value of `kid` as
 their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
+the JWK Thumbprint [[RFC7638]] using the SHA-256 hash function of the [=public key=].
 See the first key in
 [[[#example-various-verification-method-types]]] for an example of a
 public key with a compound key identifier.
@@ -2312,7 +2313,7 @@ the `proofPurpose` property in the proof. See Section
           The terms defined in this specification are also part of the
           RDF <a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]]
           <a href="https://w3id.org/security">https://w3id.org/security#</a>.
-          For any `TERM`, the relevant URL is of the form 
+          For any `TERM`, the relevant URL is of the form
           `https://w3id.org/security#TERM` or `https://w3id.org/security#TERMmethod`.
           Implementations that use RDF processing and rely on this specification MUST use these URLs.
         </p>
@@ -2322,7 +2323,7 @@ the `proofPurpose` property in the proof. See Section
           <a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
           the media type of the data that is returned depends on HTTP content negotiation. These are as follows:
         </p>
-        
+
         <table class="simple">
           <thead>
             <tr>
@@ -2337,7 +2338,7 @@ the `proofPurpose` property in the proof. See Section
               </td>
               <td>
                 The vocabulary in JSON-LD format [[?JSON-LD11]].<br>
-        
+
                 <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
         data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld"
         data-hash-format="openssl dgst -sha256" /></code>
@@ -2349,7 +2350,7 @@ the `proofPurpose` property in the proof. See Section
               </td>
               <td>
                 The vocabulary in Turtle format [[?TURTLE]].<br>
-        
+
                 <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
         data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.ttl"
         data-hash-format="openssl dgst -sha256" /></code>
@@ -2361,8 +2362,8 @@ the `proofPurpose` property in the proof. See Section
               </td>
               <td>
                 The vocabulary in HTML+RDFa Format [[?HTML-RDFA]].<br>
-        
-        
+
+
                 <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
         data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html"
         data-hash-format="openssl dgst -sha256" /></code>
@@ -2370,13 +2371,13 @@ the `proofPurpose` property in the proof. See Section
             </tr>
           </tbody>
         </table>
-        
+
         <p>
           It is possible to confirm the cryptographic digests above by running
           a command like the following (replacing `&lt;MEDIA_TYPE>` and `&lt;DOCUMENT_URL>`
           with the appropriate values) through a modern UNIX-like OS command line interface:
           `curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -sha256`
-        </p>       
+        </p>
       </section>
 
       <section>
@@ -2386,7 +2387,7 @@ the `proofPurpose` property in the proof. See Section
           JSON-LD context URL as already resolved, where the resolved document matches
           the corresponding hash value below:
         </p>
-        
+
         <table class="simple">
           <thead>
             <th>Context URL and Hash</th>
@@ -2402,13 +2403,13 @@ the `proofPurpose` property in the proof. See Section
             </tr>
           </tbody>
         </table>
-        
+
         <p>
           It is possible to confirm the cryptographic digests listed above by running a
           command like the following through a modern UNIX-like OS command line interface: `curl -sL -H
           "Accept: application/ld+json" https://www.w3.org/ns/controller/v1 | openssl dgst -sha256`
         </p>
-        
+
         <p>
           The security vocabulary terms that the JSON-LD contexts listed above resolve
           to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
@@ -2417,7 +2418,7 @@ the `proofPurpose` property in the proof. See Section
 
         <p class="note">
           Applications or specifications may define mappings to the
-          vocabulary URLs using their own JSON-LD contexts. For example, these mappings are part 
+          vocabulary URLs using their own JSON-LD contexts. For example, these mappings are part
           of the `https://w3id.org/security/data-integrity/v2` context,
           defined by the [[[?VC-DATA-INTEGRITY]]] specification, or the `https://www.w3.org/ns/did/v1` context,
           defined by the [[[?DID-CORE]]] specification.
@@ -2435,7 +2436,7 @@ the `proofPurpose` property in the proof. See Section
           <p>
             When an application is processing a [=controller document=], if an `@context`
             property is not provided in the document or the terms used in the document are
-            not mapped by existing values in the `@context` property, implementations MUST inject 
+            not mapped by existing values in the `@context` property, implementations MUST inject
             or append an `@context` property with a value of
             `https://www.w3.org/ns/controller/v1` or one or more contexts with at least the
             same declarations, such as the Decentralized Identifier v1.1 context

--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ methods</a> using both properties above is shown below.
             </pre>
           </section>
 
-          <section>
+          <section id="Multikey">
             <h3>Multikey</h3>
             <p>
 The Multikey data model is a specific type of [=verification method=] that
@@ -1142,7 +1142,7 @@ already defined by this specification.
 
           </section>
 
-          <section>
+          <section id="JsonWebKey">
             <h3>JsonWebKey</h3>
             <p>
 The JSON Web Key (JWK) data model is a specific type of [=verification method=]

--- a/index.html
+++ b/index.html
@@ -1170,7 +1170,7 @@ in the <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their [=public keys=] use the value of `kid` as
 their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
-the JWK Thumbprint [[RFC7638]] using the SHA-256 (SHA2-256) hash function of the [=public key=].
+See the first key in
 [[[#example-various-verification-method-types]]] for an example of a
 public key with a compound key identifier.
                 </p>

--- a/index.html
+++ b/index.html
@@ -1170,7 +1170,7 @@ in the <a href="https://datatracker.ietf.org/doc/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their [=public keys=] use the value of `kid` as
 their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
-the JWK Thumbprint [[RFC7638]] using the SHA-256 hash function of the [=public key=].
+the JWK Thumbprint [[RFC7638]] using the SHA-256 (SHA2-256) hash function of the [=public key=].
 See the first key in
 [[[#example-various-verification-method-types]]] for an example of a
 public key with a compound key identifier.

--- a/index.html
+++ b/index.html
@@ -2300,176 +2300,153 @@ the `proofPurpose` property in the proof. See Section
     <section>
       <h2>Contexts and Vocabularies</h2>
 
-<p class="issue" data-number="73" title="(AT RISK) Hash values might change during Candidate Recommendation">
-This section lists cryptographic hash values that might change during the
-Candidate Recommendation phase based on implementer feedback that requires
-the referenced files to be modified.
-      </p>
-      <p>
-Implementations that perform JSON-LD processing MUST treat the following
-JSON-LD context URLs as already resolved, where the resolved document matches
-the corresponding hash values below:
-      </p>
-
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>URL, Media Type, and Content Digest</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/data-integrity/v2 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/data-integrity/v2"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/multikey/v1 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/multikey/v1"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security/jwk/v1 (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3id.org/security/jwk/v1"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>
-The security vocabulary terms that the JSON-LD contexts listed above resolve
-to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
-namespace. That is, all security terms in this vocabulary are of the form
-`https://w3id.org/security#TERM`, where `TERM` is the name of a term.
-      </p>
-
-      <p>
-Implementations that perform RDF processing MUST treat the following
-JSON-LD vocabulary URL as already resolved, where the resolved document matches
-the corresponding hash values below.
-      </p>
-
-      <p>
-When dereferencing the
-<a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
-the data returned depends on HTTP content negotiation. These are as follows:
-      </p>
-
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>URL, Media Type, and Content Digest</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (application/ld+json)<br>
-<strong>SHA2-256 Digest:</strong><code><span class="vc-hash"
-data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (text/turtle)<br>
-<strong>SHA2-256 Digest:</strong><code><span class="vc-hash"
-data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.ttl"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-          <tr>
-            <td style="white-space: nowrap;">
-<strong>URL:</strong>
-https://w3id.org/security (text/html)<br>
-<strong>SHA2-256 Digest:</strong>
-<code><span class="vc-hash"
-data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html"
-data-hash-format="openssl dgst -sha256" /></code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>
-It is possible to confirm the digests listed above by running the following
-command from a modern Unix command interface line:
-`curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -sha256`.
-      </p>
-
-      <p>
-Authors of application-specific vocabularies and specifications SHOULD ensure
-that their JSON-LD context and vocabulary files are permanently cacheable
-using the approaches to caching described above or a functionally equivalent
-mechanism.
-      </p>
-
-      <p>
-Implementations MAY load application-specific JSON-LD context files from the
-network during development, but SHOULD permanently cache JSON-LD context files
-used in [=conforming documents=] in production settings to increase their
-security and privacy characteristics. Caching goals MAY be achieved through
-approaches such as those described above or functionally equivalent mechanisms.
-      </p>
-      <p>
-Some applications, such as digital wallets, that are capable of holding arbitrary
-verifiable credentials or other data-integrity-protected documents, from
-any issuer and using any contexts, might need to be able to load externally
-linked resources, such as JSON-LD context files, in production settings. This is
-expected to increase user choice, scalability, and decentralized upgrades in the
-ecosystem over time. Authors of such applications are advised to read the
-security and privacy sections of this document for further considerations.
-      </p>
-
-      <p>
-For further information regarding processing of JSON-LD contexts and
-vocabularies, see <a data-cite="?VC-DATA-MODEL-2.0#base-context">Verifiable
-Credentials v2.0: Base Context</a> and <a data-cite="?VC-DATA-MODEL-2.0#vocabularies">
-Verifiable Credentials v2.0: Vocabularies</a>.
+      <p class="issue" title="(AT RISK) Hash values might change during Candidate Recommendation">
+        This section lists cryptographic hash values that might change during the
+        Candidate Recommendation phase based on implementer feedback that requires
+        the referenced files to be modified.
       </p>
 
       <section>
-        <h3>Context Injection</h3>
-
+        <h2>Vocabulary</h2>
         <p>
-The `@context` property is used by implementations that employ JSON-LD to ensure that implementations are using the
-same semantics when terms in this specification are processed. For example, this
-can be important when properties like `type` are processed and its values, such
-as `DataIntegrityProof`, are used.
+          The terms defined in this specification are also part of the
+          RDF <a data-cite="RDF-CONCEPTS#vocabularies">vocabulary namespace</a> [[RDF-CONCEPTS]]
+          <a href="https://w3id.org/security">https://w3id.org/security#</a>.
+          For any `TERM`, the relevant URL is of the form 
+          `https://w3id.org/security#TERM` or `https://w3id.org/security#TERMmethod`.
+          Implementations that use RDF processing and rely on this specification MUST use these URLs.
         </p>
 
         <p>
-If an `@context` property is not provided in a document that is being secured or
-verified, or any Data Integrity terms used in the document are not mapped by
-existing values in the `@context` property, implementations using JSON-LD MUST inject or add
-an `@context` property with a value of
-`https://www.w3.org/ns/controller/v1`.
+          When dereferencing the
+          <a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
+          the media type of the data that is returned depends on HTTP content negotiation. These are as follows:
+        </p>
+        
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>Media Type</th>
+              <th>Description and Hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                application/ld+json
+              </td>
+              <td>
+                The vocabulary in JSON-LD format [[?JSON-LD11]].<br>
+        
+                <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
+        data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld"
+        data-hash-format="openssl dgst -sha256" /></code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                text/turtle
+              </td>
+              <td>
+                The vocabulary in Turtle format [[?TURTLE]].<br>
+        
+                <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
+        data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.ttl"
+        data-hash-format="openssl dgst -sha256" /></code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                text/html
+              </td>
+              <td>
+                The vocabulary in HTML+RDFa Format [[?HTML-RDFA]].<br>
+        
+        
+                <strong>SHA2-256 Digest:</strong> <code><span class="vc-hash"
+        data-hash-url="https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html"
+        data-hash-format="openssl dgst -sha256" /></code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+        <p>
+          It is possible to confirm the cryptographic digests above by running
+          a command like the following (replacing `&lt;MEDIA_TYPE>` and `&lt;DOCUMENT_URL>`
+          with the appropriate values) through a modern UNIX-like OS command line interface:
+          `curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -sha256`
+        </p>       
+      </section>
+
+      <section>
+        <h3>JSON-LD context</h3>
+        <p>
+          Implementations that perform JSON-LD processing MUST treat the following
+          JSON-LD context URL as already resolved, where the resolved document matches
+          the corresponding hash value below:
+        </p>
+        
+        <table class="simple">
+          <thead>
+            <th>Context URL and Hash</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td style="white-space: nowrap;">
+                <strong>URL:</strong> https://www.w3.org/ns/controller/v1<br>
+                <strong>SHA2-256 Digest:</strong><br> <code><span class="vc-hash"
+        data-hash-url="https://w3c.github.io/controller-document/context/v1.jsonld"
+        data-hash-format="openssl dgst -sha256" /></code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+        <p>
+          It is possible to confirm the cryptographic digests listed above by running a
+          command like the following through a modern UNIX-like OS command line interface: `curl -sL -H
+          "Accept: application/ld+json" https://www.w3.org/ns/controller/v1 | openssl dgst -sha256`
+        </p>
+        
+        <p>
+          The security vocabulary terms that the JSON-LD contexts listed above resolve
+          to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
+          namespace. See also <a href="#vocabulary"></a> for further details.
         </p>
 
-        <p>
-Context injection is expected to be unnecessary sometimes, such as when the Verifiable
-Credential Data Model v2.0 context (`https://www.w3.org/ns/credentials/v2`)
-exists as a value in the `@context` property, as that context maps all of the
-necessary Data Integrity terms that were previously mapped by
-`https://w3id.org/security/data-integrity/v2`.
+        <p class="note">
+          Applications or specifications may define mappings to the
+          vocabulary URLs using their own JSON-LD contexts. For example, these mappings are part 
+          of the `https://w3id.org/security/data-integrity/v2` context,
+          defined by the [[[?VC-DATA-INTEGRITY]]] specification, or the `https://www.w3.org/ns/did/v1` context,
+          defined by the [[[?DID-CORE]]] specification.
         </p>
+
+        <section>
+          <h4>Context injection</h4>
+          <p>
+            The `@context` property is used to ensure that implementations are using the
+            same semantics when terms in this specification are processed. For example, this
+            can be important when properties like `authentication` are processed and its
+            value, such as `Multikey` or `JsonWebKey`, are used.
+          </p>
+
+          <p>
+            When an application is processing a [=controller document=], if an `@context`
+            property is not provided in the document or the terms used in the document are
+            not mapped by existing values in the `@context` property, implementations MUST inject 
+            or append an `@context` property with a value of
+            `https://www.w3.org/ns/controller/v1` or one or more contexts with at least the
+            same declarations, such as the Decentralized Identifier v1.1 context
+            (`https://www.w3.org/ns/did/v1`).
+          </p>
+
+          <p>
+            Implementations that do not intend to use JSON-LD MAY choose to not include an
+            `@context` declaration at the top-level of the document.
+          </p>
+        </section>
       </section>
 
       <section>


### PR DESCRIPTION
This is an alternative to PRs #90 and #43, following the proposal in https://github.com/w3c/controller-document/pull/90#issuecomment-2325588311, and also discussed in our call https://www.w3.org/2017/vc/WG/Meetings/Minutes/2024-09-04-vcwg#section2-2. If merged, this PR also takes care of #10 and #70.

Note that the PR also includes a first version for a `@context` file at `./context/v1.json`.

Some more comments:

- In copying the text from #90, the comment of @selfissued has also been taken care of
- At the moment, the redirection of `/ns/controller/v1` has not yet been installed; this is to be done if this PR can be merged.
- The table in the section on contexts does not yet display the SHA value of the context file but, instead, shows an error message. This will automatically solve itself when everything gets merged.

CCing @BigBlueHat and @davidlehn for a review of the `@context` file.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/92.html" title="Last updated on Sep 11, 2024, 12:49 PM UTC (51fb8a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/92/1709c9e...51fb8a0.html" title="Last updated on Sep 11, 2024, 12:49 PM UTC (51fb8a0)">Diff</a>