### PR TITLE
Added an expiration property

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,19 +825,22 @@ method</a> type. This specification defines the types `JsonWebKey` (see Section
 The value of the `controller` property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 </dd>
-<!-- VC-DATA-INTEGRITY-SPECIFIC:
+
                 <dt id="defn-vm-expires">expires</dt>
                 <dd>
-The `expires` property is OPTIONAL. It is set, in advance, by the
+The `expires` property is OPTIONAL. 
+<!-- VC-DATA-INTEGRITY-SPECIFIC:
+ It is set, in advance, by the
 [=controller=] of a  [=verification method=] to signal when that method
-can no longer be used for verification purposes. If provided, it MUST be an
+can no longer be used for verification purposes. 
+-->
+If provided, it MUST be an
 [[XMLSCHEMA11-2]] `dateTimeStamp` string specifying when the
 [=verification method=] SHOULD cease to be used. Once the value is set, it is
 not expected to be updated, and systems depending on the value are expected to
 not verify any proofs associated with the [=verification method=] at or after
 the time of expiration.
                 </dd>
--->
                 <dt><dfn class="lint-ignore">revoked</dfn></dt>
                 <dd>
 The `revoked` property is OPTIONAL.

--- a/index.html
+++ b/index.html
@@ -852,7 +852,7 @@ for verification purposes, such as after a security compromise of the
 -->
 If present, it MUST be an [[XMLSCHEMA11-2]]
 `dateTimeStamp` string specifying when the [=verification method=]
-SHOULD cease to be used. Once the value is set, it is not expected to be
+MUST NOT be used. Once the value is set, it is not expected to be
 updated, and systems depending on the value are expected to not verify any
 proofs associated with the [=verification method=] at or after the time of
 revocation.


### PR DESCRIPTION
Releated to the issues and comments in https://github.com/w3c/controller-document/pull/92#discussion_r1749537440: the `expires` property was present in the DI version of the verification methods, and remained commented out in the controller spec. This is probably a property to be re-instated.

Note that the current text (which I took by removing some comment lines) is identical to `revoked`. What differentiates these two? Per the spec, nothing...

A separate PR will be raised on the DI Vocabulary to make this valid.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/96.html" title="Last updated on Sep 12, 2024, 6:41 AM UTC (7041f2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/96/1709c9e...7041f2c.html" title="Last updated on Sep 12, 2024, 6:41 AM UTC (7041f2c)">Diff</a>