### PR TITLE
ID value mix up

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ methods</a> using both properties above is shown below.
             </pre>
           </section>
 
-          <section id="Multikey">
+          <section>
             <h3>Multikey</h3>
             <p>
 The Multikey data model is a specific type of [=verification method=] that
@@ -1142,7 +1142,7 @@ already defined by this specification.
 
           </section>
 
-          <section id="JsonWebKey">
+          <section>
             <h3>JsonWebKey</h3>
             <p>
 The JSON Web Key (JWK) data model is a specific type of [=verification method=]


### PR DESCRIPTION
A hidden merge conflict occured with the `#jsonwebkey` vs. `#JsonWebKey` (and the same with multikeys), which currently led to a respec error (and hence echidna did not publish the last version).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/98.html" title="Last updated on Sep 17, 2024, 3:24 PM UTC (dbe17c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/98/cb5b922...dbe17c0.html" title="Last updated on Sep 17, 2024, 3:24 PM UTC (dbe17c0)">Diff</a>