### PR TITLE
Add Service feature based on W3C TPAC 2024 discussion.

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,6 +769,89 @@ not necessarily appropriate, <em>even with</em> a reciprocal relationship.
 
           </section>
 
+          <section>
+            <h2>Services</h2>
+
+            <p>
+[=Services=] are used in [=controller documents=] to express ways of
+communicating with the [=subject=] or associated entities. A [=service=] can be
+any type of service the [=subject=] wants to advertise for further discovery,
+authentication, authorization, or interaction.
+            </p>
+
+            <p>
+Due to privacy concerns, revealing public information through [=services=], such
+as social media accounts, personal websites, and email addresses, is
+discouraged. Further exploration of privacy concerns can be found in
+[=#keep-personal-data-private=] and [=#service-privacy=]. The information
+associated with [=services=] is often service specific. For example, the
+information associated with an encrypted messaging service can express how to
+initiate the encrypted link before messaging begins.
+            </p>
+
+            <p>
+[=Services=] are expressed using the `service` property, which is described
+below:
+            </p>
+
+            <dl>
+              <dt><dfn>service</dfn></dt>
+              <dd>
+                <p>
+The `service` property is OPTIONAL. If present, the associated value MUST be a
+<a data-cite="INFRA#ordered-set">set</a> of [=services=], where each service is
+described by a <a data-cite="INFRA#ordered-map">map</a>. Each [=service=] <a
+data-cite="INFRA#ordered-map">map</a> MUST contain `id`, `type`, and
+`serviceEndpoint` properties. Each service extension MAY include additional
+properties and MAY further restrict the properties associated with the
+extension.
+                </p>
+                <dl>
+                  <dt id="prop-service-id">id</dt>
+                  <dd>
+An OPTIONAL property where the value of the `id` property MUST be a URL
+conforming to [[[URL]]]. A [=conforming document=] MUST NOT include multiple
+`service` entries with the same `id`.
+                  </dd>
+                <dt id="prop-service-type">type</dt>
+                <dd>
+A REQUIRED property where the value of the `type` property MUST be a
+<a data-cite="INFRA#string">string</a> or a
+<a data-cite="INFRA#ordered-set">set</a> of
+<a data-cite="INFRA#string">strings</a>. In order to maximize interoperability,
+the [=service=] type and its associated properties SHOULD be registered in the
+[[[?VC-EXTENSIONS]]].
+                </dd>
+                <dt id="prop-service-endpoint">serviceEndpoint</dt>
+                <dd>
+The value of the `serviceEndpoint` property MUST be a
+<a data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#maps">map</a>, or
+a <a data-cite="INFRA#ordered-set">set</a> composed of one or more
+<a data-cite="INFRA#string">strings</a> and/or
+<a data-cite="INFRA#maps">maps</a>. All <a data-cite="INFRA#string">string</a>
+values MUST be valid URLs conforming to [[[URL]]].
+                </dd>
+              </dl>
+            </dl>
+
+            <p>
+For more information regarding privacy and security considerations related to
+[=services=] see [[[#service-privacy]]], [[[#keep-personal-data-private]]],
+[[[#controller-document-correlation-risks]]], and
+[[[#authentication-service-endpoints]]].
+      </p>
+
+      <pre class="example nohighlight" title="Usage of the service property">
+{
+  "service": [{
+    "type": "ExampleSocialMediaService",
+    "serviceEndpoint": "https://warbler.example/sal674"
+  }]
+}
+            </pre>
+
+          </section>
+
         </section>
 
         <section>
@@ -2416,7 +2499,7 @@ the `proofPurpose` property in the proof. See Section
         <p>
           The security vocabulary terms that the JSON-LD contexts listed above resolve
           to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
-          namespace. See also <a href="#vocabulary"></a> for further details.
+          namespace. See also [[[#vocabulary]]] for further details.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -809,27 +809,28 @@ extension.
                 <dl>
                   <dt id="prop-service-id">id</dt>
                   <dd>
-An OPTIONAL property where the value of the `id` property MUST be a URL
+The `id` property is OPTIONAL. If present, its value MUST be a URL
 conforming to [[[URL]]]. A [=conforming document=] MUST NOT include multiple
 `service` entries with the same `id`.
                   </dd>
                 <dt id="prop-service-type">type</dt>
                 <dd>
-A REQUIRED property where the value of the `type` property MUST be a
+The `type` property is REQUIRED. Its value MUST be a
 <a data-cite="INFRA#string">string</a> or a
 <a data-cite="INFRA#ordered-set">set</a> of
-<a data-cite="INFRA#string">strings</a>. In order to maximize interoperability,
+<a data-cite="INFRA#string">strings</a>. To maximize interoperability,
 the [=service=] type and its associated properties SHOULD be registered in the
 [[[?VC-EXTENSIONS]]].
                 </dd>
                 <dt id="prop-service-endpoint">serviceEndpoint</dt>
                 <dd>
-The value of the `serviceEndpoint` property MUST be a
-<a data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#maps">map</a>, or
-a <a data-cite="INFRA#ordered-set">set</a> composed of one or more
+The `serviceEndpoint` property is REQUIRED. The value of the `serviceEndpoint`
+property MUST be a single <a data-cite="INFRA#string">string</a>, a single
+<a data-cite="INFRA#maps">map</a>, or a <a data-cite="INFRA#ordered-set">set</a>
+composed of one or more
 <a data-cite="INFRA#string">strings</a> and/or
-<a data-cite="INFRA#maps">maps</a>. All <a data-cite="INFRA#string">string</a>
-values MUST be valid URLs conforming to [[[URL]]].
+<a data-cite="INFRA#maps">maps</a>. Each <a data-cite="INFRA#string">string</a>
+value MUST be a valid URL conforming to [[[URL]]].
                 </dd>
               </dl>
             </dl>


### PR DESCRIPTION
During the DID WG meeting at W3C TPAC, it was noted that the Controller Document specification doesn't include service descriptions and that is a mistake. This PR addresses the issue raised and ensures that services can be expressed on Controller Documents as they are expressed on DID Documents today, bringing the two document types in parity with one another.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/99.html" title="Last updated on Oct 6, 2024, 3:33 PM UTC (3877587)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/99/0161528...3877587.html" title="Last updated on Oct 6, 2024, 3:33 PM UTC (3877587)">Diff</a>