### PR TITLE
Specify that semantics are the same if @context is not used.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2532,8 +2532,8 @@ same declarations, such as the Decentralized Identifier v1.1 context
 
           <p>
 Implementations that do not intend to use JSON-LD MAY choose to not include an
-`@context` declaration at the top-level of the document. Whether the `@context`
-value or JSON-LD processors are used or not, the semantics for all properties
+`@context` declaration at the top-level of the document. Whether or not the
+`@context` value or JSON-LD processors are used, the semantics for all properties
 and values expressed in [=conforming documents=] interpreted by [=conforming
 processors=] are the same. Any differences in semantics between documents
 processed in either mode are either implementation or specification bugs.

--- a/index.html
+++ b/index.html
@@ -2532,7 +2532,11 @@ same declarations, such as the Decentralized Identifier v1.1 context
 
           <p>
 Implementations that do not intend to use JSON-LD MAY choose to not include an
-`@context` declaration at the top-level of the document.
+`@context` declaration at the top-level of the document. Whether the `@context`
+value or JSON-LD processors are used or not, the semantics for all properties
+and values expressed in [=conforming documents=] interpreted by [=conforming
+processors=] are the same. Any differences in semantics between documents
+processed in either mode are either implementation or specification bugs.
           </p>
         </section>
       </section>


### PR DESCRIPTION
This PR is an attempt to partially address issue #94 by specifying that document semantics are the same even when `@context` is not used.

/cc @jyasskin and @hadleybeeman


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/106.html" title="Last updated on Oct 19, 2024, 8:57 PM UTC (1927601)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/106/3342340...1927601.html" title="Last updated on Oct 19, 2024, 8:57 PM UTC (1927601)">Diff</a>