### PR TITLE
Add section on integrity protection of remote controller documents.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2958,6 +2958,36 @@ version of the external JSON-LD Context.
     </section>
 
     <section>
+      <h2>Integrity Protection of Controllers</h2>
+
+      <p>
+As described in Section [[[#controllers]]], this specification provides for a
+mechanism to delegate change control of a [=controller document=] to an entity
+that is described in an external [=controller document=] through the use of the
+`controller` property.
+      </p>
+
+      <p>
+Delegating change control addresses a number of use cases including ones
+where an individual is responsible for the care of another individual and
+ones where an entity desires another to provide account recovery services.
+For these class of use cases, it can be beneficial to allow the guardian to
+manage the rotation of their own key material. It can also be beneficial for
+the delegator to associate a cryptographic hash of the remote
+[=controller document=] to "pin" the remote document to a known good value.
+      </p>
+
+      <p>
+While this document does not specify a particular mechanism for
+cryptographically protected URLs, the `relatedResource` property in
+[[[VC-DATA-MODEL-2.0]]] and the `digestMultibase` property in
+[[[VC-DATA-INTEGRITY]]] are possible mechanisms that would provide such a
+protection.
+      </p>
+
+    </section>
+
+    <section>
       <h2>Level of Assurance</h2>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -2233,12 +2233,12 @@ function baseDecode(sourceEncoding, sourceBase, baseAlphabet) {
         <p>
 The following algorithm specifies how to safely retrieve a verification method,
 such as a cryptographic [=public key=], by using a [=verification method=]
-identifier. Required inputs are a
-<strong>[=verification method=]</strong> (<var>verificationMethod</var>), a
+identifier. Required inputs are a <strong>[=verification method=]</strong>
+identifier (<var>verificationMethod</var>), a
 <strong>[=verification relationship=]</strong>
 (<var>verificationRelationship</var>), and a set of <strong>dereferencing
 options</strong> (<var>options</var>). A
-<strong>verification method</strong> is produced as output.
+<strong>[=verification method=]</strong> is produced as output.
         </p>
 
         <ol class="algorithm">
@@ -2246,8 +2246,8 @@ options</strong> (<var>options</var>). A
 Let <var>vmIdentifier</var> be set to <var>verificationMethod</var>.
           </li>
           <li>
-If <var>vmIdentifier</var> is not a valid URL, an error MUST be raised and SHOULD
-convey an error type of
+If <var>vmIdentifier</var> is not a valid URL, an error MUST be raised and
+SHOULD convey an error type of
 <a href="#INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL</a>.
           </li>
           <li>
@@ -2297,7 +2297,7 @@ INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</a>.
           </li>
           <li>
 Return <var>verificationMethod</var> as the
-<strong>verification method</strong>.
+<strong>[=verification method=]</strong>.
           </li>
         </ol>
 
@@ -2321,31 +2321,38 @@ The following example provides a minimum conformant
         </pre>
 
         <p class="note" title="Controller documents can contain references to external verification methods">
-[=Verification methods=] are identified via the `id` property, whose value is a
-URL. It is possible for a [=controller document=] to specify a [=verification
-method=], through a [=verification relationship=], that exists in a place that
-is external to the [=controller document=]. As described in Section
-[[[#integrity-protection-of-controllers]]], specifying a [=verification method=]
-that is external to a [=controller document=] is a valid use of this
-specification. When retrieving any [=verification method=], especially when the
-[=verification method=] might be cached, it is vital that the algorithm above is
-used to confirm that the [=controller document=] refers to the
-[=verification method=] (via a [=verification relationship=])
-and that the [=verification method=] refers to the [=controller document=]
-(via the [=verification method=]'s `controller` property). Failure to
-confirm that these reciprocal relationships exist can lead to security
-compromises where an attacker poisons a cache by claiming control of a
-[=verification method=] without the consent (that is, without a reciprocal
+[=Verification methods=] are expressed as strings that are URLs, or identified
+via the `id` property, whose value is a URL. It is possible for a [=controller
+document=] to specify a [=verification method=], through a [=verification
+relationship=], that exists in a place that is external to the [=controller
+document=]. As described in Section [[[#integrity-protection-of-controllers]]],
+specifying a [=verification method=] that is external to a [=controller
+document=] is a valid use of this specification. When retrieving any
+[=verification method=], especially when the [=verification method=] might be
+cached, it is vital that the algorithm above is used to confirm that the
+[=controller document=] refers to the [=verification method=] (via a
+[=verification relationship=]) and that the [=verification method=] refers to
+the [=controller document=] (via the [=verification method=]'s `controller`
+property). Failure to confirm that these reciprocal relationships exist can lead
+to security compromises where an attacker poisons a cache by claiming control of
+a [=verification method=] without the consent (that is, without a reciprocal
 reference) of the victim.
         </p>
 
         <pre class="example nohighlight" title="Referencing an external verification method for `capabilityInvocation`">
 {
   "id": "https://controller.example/123",
-  "capabilityInvocation": [<span class="highligh">"https://external.example/xyz#key-789"</span>]
+  "capabilityInvocation": [<span class="highlight">"https://external.example/xyz#key-789"</span>]
 }
         </pre>
 
+        <p>
+In the example above, the algorithm described in this section will use the
+`https://external.example/xyz#key-789` URL value as the [=verification method=]
+identifier. The algorithm will then confirm that the key exists in the
+external controller document, and that the reciprocal reference exists as
+described earlier in this section.
+        </p>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2961,28 +2961,29 @@ version of the external JSON-LD Context.
       <h2>Integrity Protection of Controllers</h2>
 
       <p>
-As described in Section [[[#controllers]]], this specification provides for a
-mechanism to delegate change control of a [=controller document=] to an entity
-that is described in an external [=controller document=] through the use of the
-`controller` property.
+As described in Section [[[#controllers]]], this specification includes a
+mechanism by which to delegate change control of a [=controller document=] to
+an entity that is described in an external [=controller document=] through the
+use of the `controller` property.
       </p>
 
       <p>
-Delegating change control addresses a number of use cases including ones
-where an individual is responsible for the care of another individual and
-ones where an entity desires another to provide account recovery services.
-For these class of use cases, it can be beneficial to allow the guardian to
-manage the rotation of their own key material. It can also be beneficial for
-the delegator to associate a cryptographic hash of the remote
-[=controller document=] to "pin" the remote document to a known good value.
+Delegating change control addresses a number of use cases including those
+where the care of an entity is the responsibility of some other entity or
+entities, as well as those where some entity desires that another entity
+provide account recovery services, among other use cases. In such scenarios,
+it can be beneficial to allow the guardian to manage the rotation of their
+own key material. It can also be beneficial for the delegator to associate
+a cryptographic hash of the remote [=controller document=] to "pin" the
+remote document to a known good value.
       </p>
 
       <p>
 While this document does not specify a particular mechanism for
 cryptographically protected URLs, the `relatedResource` property in
 [[[VC-DATA-MODEL-2.0]]] and the `digestMultibase` property in
-[[[VC-DATA-INTEGRITY]]] are possible mechanisms that would provide such a
-protection.
+[[[VC-DATA-INTEGRITY]]] could be employed by a mechanism that can provide
+such protection.
       </p>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -2234,7 +2234,7 @@ function baseDecode(sourceEncoding, sourceBase, baseAlphabet) {
 The following algorithm specifies how to safely retrieve a verification method,
 such as a cryptographic [=public key=], by using a [=verification method=]
 identifier. Required inputs are a <strong>[=verification method=]</strong>
-identifier (<var>verificationMethod</var>), a
+identifier (<var>vmIdentifier</var>), a
 <strong>[=verification relationship=]</strong>
 (<var>verificationRelationship</var>), and a set of <strong>dereferencing
 options</strong> (<var>options</var>). A
@@ -2242,9 +2242,6 @@ options</strong> (<var>options</var>). A
         </p>
 
         <ol class="algorithm">
-          <li>
-Let <var>vmIdentifier</var> be set to <var>verificationMethod</var>.
-          </li>
           <li>
 If <var>vmIdentifier</var> is not a valid URL, an error MUST be raised and
 SHOULD convey an error type of
@@ -2289,15 +2286,21 @@ an error MUST be raised and SHOULD convey an error type of
           </li>
           <li>
 If the absolute URL value of <var>verificationMethod</var>.<var>id</var>
-does not start with the <var>controllerDocumentUrl</var>, an error MUST be
-raised and SHOULD convey an error type of
-<a href="#INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL</a>.
+does not equal <var>vmIdentifier</var>, an error MUST be raised and SHOULD
+convey an error type of
+<a href="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
           </li>
           <li>
-If the [=verification method=] is not associated with a
-[=verification relationship=] array in the <var>controllerDocument</var>,
-either by reference (URL) or by value (object), an error MUST be raised and
+If the absolute URL value of <var>verificationMethod</var>.<var>controller</var>
+does not equal <var>controllerDocumentUrl</var>, an error MUST be raised and
 SHOULD convey an error type of
+<a href="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
+          </li>
+          <li>
+If <var>verificationMethod</var> is not associated, either by reference
+(URL) or by value (object), with the [=verification relationship=] array in the
+<var>controllerDocument</var> identified by <var>verificationRelationship</var>,
+an error MUST be raised and SHOULD convey an error type of
 <a href="#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">
 INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</a>.
           </li>
@@ -2327,22 +2330,26 @@ The following example provides a minimum conformant
         </pre>
 
         <p class="note" title="Controller documents can contain references to external verification methods">
-[=Verification methods=] are expressed as strings that are URLs, or identified
+[=Verification method=] identifiers are expressed as strings that are URLs, or
 via the `id` property, whose value is a URL. It is possible for a [=controller
-document=] to specify a [=verification method=], through a [=verification
+document=] to express a [=verification method=], through a [=verification
 relationship=], that exists in a place that is external to the [=controller
 document=]. As described in Section [[[#integrity-protection-of-controllers]]],
 specifying a [=verification method=] that is external to a [=controller
-document=] is a valid use of this specification. When retrieving any
-[=verification method=], especially when the [=verification method=] might be
-cached, it is vital that the algorithm above is used to confirm that the
-[=controller document=] refers to the [=verification method=] (via a
-[=verification relationship=]) and that the [=verification method=] refers to
-the [=controller document=] (via the [=verification method=]'s `controller`
-property). Failure to confirm that these reciprocal relationships exist can lead
-to security compromises where an attacker poisons a cache by claiming control of
-a [=verification method=] without the consent (that is, without a reciprocal
-reference) of the victim.
+document=] is a valid use of this specification. It is vital that this
+[=verification method=] is retrieved from the external [=controller document=].
+        </p>
+
+        <p>
+When retrieving any [=verification method=] the algorithm above is used to
+ensure that the [=verification method=] is retrieved from the correct
+[=controller document=]. The algorithm also ensures that this [=controller
+document=] refers to the [=verification method=] (via a [=verification
+relationship=]) and that the [=verification method=] refers to the [=controller
+document=] (via the [=verification method=]'s `controller` property). Failure to
+use this algorithm, or an equivalent one that performs these checks, can lead to
+security compromises where an attacker poisons a cache by claiming control of a
+victim's [=verification method=].
         </p>
 
         <pre class="example nohighlight" title="Referencing an external verification method for `capabilityInvocation`">
@@ -2355,9 +2362,9 @@ reference) of the victim.
         <p>
 In the example above, the algorithm described in this section will use the
 `https://external.example/xyz#key-789` URL value as the [=verification method=]
-identifier. The algorithm will then confirm that the key exists in the
-external controller document, and that the reciprocal reference exists as
-described earlier in this section.
+identifier. The algorithm will then confirm that the [=verification method=]
+exists in the external [=controller document=] and that the appropriate
+relationships exist as described earlier in this section.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2266,16 +2266,16 @@ Let <var>controllerDocument</var> be the result of dereferencing
 of the URL scheme and using the supplied <var>options</var>.
           </li>
           <li>
-If <var>controllerDocument</var>.<var>id</var> does not match the
-<var>controllerDocumentUrl</var>, an error MUST be raised and SHOULD
-convey an error type of
-<a href="#INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID</a>.
-          </li>
-          <li>
 If <var>controllerDocument</var> is not a [=conforming controller document=],
 an error MUST be raised and SHOULD
 convey an error type of
 <a href="#INVALID_CONTROLLER_DOCUMENT">INVALID_CONTROLLER_DOCUMENT</a>.
+          </li>
+          <li>
+If <var>controllerDocument</var>.<var>id</var> does not match the
+<var>controllerDocumentUrl</var>, an error MUST be raised and SHOULD
+convey an error type of
+<a href="#INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID</a>.
           </li>
           <li>
 Let <var>verificationMethod</var> be the result of dereferencing the
@@ -2286,6 +2286,12 @@ rules of the media type of the <var>controllerDocument</var>.
 If <var>verificationMethod</var> is not a [=conforming verification method=],
 an error MUST be raised and SHOULD convey an error type of
 <a href="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
+          </li>
+          <li>
+If the absolute URL value of <var>verificationMethod</var>.<var>id</var>
+does not start with the <var>controllerDocumentUrl</var>, an error MUST be
+raised and SHOULD convey an error type of
+<a href="#INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL</a>.
           </li>
           <li>
 If the [=verification method=] is not associated with a


### PR DESCRIPTION
This PR is an attempt to partially address issue #94 by adding a security consideration section on integrity protection of remote controller documents.

/cc @jyasskin and @hadleybeeman


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/108.html" title="Last updated on Oct 19, 2024, 8:35 PM UTC (d27de6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/108/2e417ee...d27de6f.html" title="Last updated on Oct 19, 2024, 8:35 PM UTC (d27de6f)">Diff</a>