### PR TITLE
Explain that references to external verification methods are allowed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,10 @@ code {
   color: rgb(199, 73, 0);
   font-weight: bold;
 }
+pre.highlight {
+  font-weight: bold;
+  color: green;
+}
 pre.nohighlight {
   overflow-x: auto;
   white-space: pre-wrap;
@@ -2315,6 +2319,32 @@ The following example provides a minimum conformant
   "authentication": ["#key-456"]
 }
         </pre>
+
+        <p class="note" title="Controller documents can contain references to external verification methods">
+[=Verification methods=] are identified via the `id` property, whose value is a
+URL. It is possible for a [=controller document=] to specify a [=verification
+method=], through a [=verification relationship=], that exists in a place that
+is external to the [=controller document=]. As described in Section
+[[[#integrity-protection-of-controllers]]], specifying a [=verification method=]
+that is external to a [=controller document=] is a valid usage of this
+specification. When retrieving any [=verification method=], especially when the
+[=verification method=] might be cached, it is vital that the algorithm above is
+used to ensure that there is a bi-directional reference from the [=controller
+document=] to the [=verification method=] (via a [=verification relationship=])
+and from the [=verification method=] to the [=controller document=] (via the
+[=verification method=]'s `controller` property). Not ensuring this
+bi-directional relationship exists can lead to security compromises where an
+attacker poisons a cache by claiming control of a [=verification method=]
+without the consent (that is, without a bi-directional reference) of the victim.
+        </p>
+
+        <pre class="example nohighlight" title="Referencing an external verification method for `capabilityInvocation`">
+{
+  "id": "https://controller.example/123",
+  "capabilityInvocation": [<span class="highligh">"https://external.example/xyz#key-789"</span>]
+}
+        </pre>
+
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2326,16 +2326,17 @@ URL. It is possible for a [=controller document=] to specify a [=verification
 method=], through a [=verification relationship=], that exists in a place that
 is external to the [=controller document=]. As described in Section
 [[[#integrity-protection-of-controllers]]], specifying a [=verification method=]
-that is external to a [=controller document=] is a valid usage of this
+that is external to a [=controller document=] is a valid use of this
 specification. When retrieving any [=verification method=], especially when the
 [=verification method=] might be cached, it is vital that the algorithm above is
-used to ensure that there is a bi-directional reference from the [=controller
-document=] to the [=verification method=] (via a [=verification relationship=])
-and from the [=verification method=] to the [=controller document=] (via the
-[=verification method=]'s `controller` property). Not ensuring this
-bi-directional relationship exists can lead to security compromises where an
-attacker poisons a cache by claiming control of a [=verification method=]
-without the consent (that is, without a bi-directional reference) of the victim.
+used to confirm that the [=controller document=] refers to the
+[=verification method=] (via a [=verification relationship=])
+and that the [=verification method=] refers to the [=controller document=]
+(via the [=verification method=]'s `controller` property). Failure to
+confirm that these reciprocal relationships exist can lead to security
+compromises where an attacker poisons a cache by claiming control of a
+[=verification method=] without the consent (that is, without a reciprocal
+reference) of the victim.
         </p>
 
         <pre class="example nohighlight" title="Referencing an external verification method for `capabilityInvocation`">


### PR DESCRIPTION
This PR is an attempt to partially address issue #94 by explaining that references to external verification methods are allowed and dereferencing those values must be done using the algorithm in the specification.

/cc @jyasskin and @hadleybeeman


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/109.html" title="Last updated on Oct 19, 2024, 4:54 PM UTC (1376386)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/109/3342340...1376386.html" title="Last updated on Oct 19, 2024, 4:54 PM UTC (1376386)">Diff</a>