### PR TITLE
Add `service` to document properties and context.

### DIFF
--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -38,6 +38,11 @@
       "@type": "@id",
       "@container": "@set"
     },
+    "service": {
+      "@id": "https://www.w3.org/ns/did#service",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "verificationMethod": {
       "@id": "https://w3id.org/security#verificationMethod",
       "@type": "@id",

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -41,8 +41,16 @@
     "service": {
       "@id": "https://www.w3.org/ns/did#service",
       "@type": "@id",
-      "@container": "@set"
-    },
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },    
     "verificationMethod": {
       "@id": "https://w3id.org/security#verificationMethod",
       "@type": "@id",

--- a/index.html
+++ b/index.html
@@ -715,6 +715,15 @@ syntax.
                 <td style="white-space: nowrap;">[[[#also-known-as]]]</td>
               </tr>
               <tr>
+                <td>`service`</td>
+                <td>no</td>
+                <td>
+A <a data-cite="INFRA#ordered-set">set</a> of [=service=]
+<a data-cite="INFRA#ordered-map">maps</a>.
+                </td>
+                <td style="white-space: nowrap;">[[[#services]]]</td>
+              </tr>
+              <tr>
                 <td>`verificationMethod`</td>
                 <td>no</td>
                 <td>


### PR DESCRIPTION
This PR is an attempt to address issue #110 by adding `service` to controller document properties and the `controller/v1` context. 

/cc @filip26


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/112.html" title="Last updated on Oct 21, 2024, 4:26 PM UTC (f70ae01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/112/177f727...f70ae01.html" title="Last updated on Oct 21, 2024, 4:26 PM UTC (f70ae01)">Diff</a>