### PR TITLE
Use correct vocabulary URL for `alsoKnownAs`.

### DIFF
--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -5,9 +5,8 @@
     "type": "@type",
 
     "alsoKnownAs": {
-      "@id": "https://w3id.org/security#alsoKnownAs",
-      "@type": "@id",
-      "@container": "@set"
+      "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
+      "@type": "@id"
     },
     "assertionMethod": {
       "@id": "https://w3id.org/security#assertionMethod",

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -39,10 +39,9 @@
     },
     "verificationMethod": {
       "@id": "https://w3id.org/security#verificationMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
-   "Multikey": {
+    "Multikey": {
       "@id": "https://w3id.org/security#Multikey",
       "@context": {
         "@protected": true,
@@ -70,7 +69,7 @@
         }
       }
     },
-   "JsonWebKey": {
+    "JsonWebKey": {
       "@id": "https://w3id.org/security#JsonWebKey",
       "@context": {
         "@protected": true,


### PR DESCRIPTION
This PR is an attempt to address issue #111 by using the correct ActivityStreams vocabulary URL for `alsoKnownAs`.

/cc @trwnh