### PR TITLE
Clarify that mechanism for capability delegation is application-specific.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1879,7 +1879,7 @@ protected resource.
 
             <p>
 The `capabilityDelegation` [=verification relationship=] is used to specify a
-mechanism that might be used by the [=controller=] to delegate a cryptographic
+mechanism that might be used to delegate a cryptographic
 capability to another party. The mechanism, such as an
 <a href="https://w3c-ccg.github.io/zcap-spec/">Authorization Capability</a>
 or a <a href="https://github.com/ucan-wg/spec/blob/main/README.md">UCAN</a>, and

--- a/index.html
+++ b/index.html
@@ -1878,10 +1878,13 @@ protected resource.
             <h2>Capability Delegation</h2>
 
             <p>
-The `capabilityDelegation` [=verification relationship=] is used
-to specify a mechanism that might be used by the [=controller=] to delegate
-a cryptographic capability to another party, such as delegating the authority
-to access a specific HTTP API to a subordinate.
+The `capabilityDelegation` [=verification relationship=] is used to specify a
+mechanism that might be used by the [=controller=] to delegate a cryptographic
+capability to another party. The mechanism, such as an
+<a href="https://w3c-ccg.github.io/zcap-spec/">Authorization Capability</a>
+or a <a href="https://github.com/ucan-wg/spec/blob/main/README.md">UCAN</a>, and
+the processing performed following delegation, such as accessing a specific HTTP
+API, is application-specific.
             </p>
 
             <dl>


### PR DESCRIPTION
This PR is an attempt to address issue #64 by using @selfissued's suggestion that the mechanism for capability delegation is application-specific.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/123.html" title="Last updated on Nov 16, 2024, 8:25 PM UTC (bfe0830)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/123/f2baa07...bfe0830.html" title="Last updated on Nov 16, 2024, 8:25 PM UTC (bfe0830)">Diff</a>