### PR TITLE
Add example that does not contain `@context`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2763,7 +2763,7 @@ same declarations, such as the Decentralized Identifier v1.1 context
       "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
     }
   }],
-  "authentication": ["#key-20240828"]
+  "authentication": ["#key-203947"]
 }
           </pre>
 

--- a/index.html
+++ b/index.html
@@ -2747,6 +2747,26 @@ same declarations, such as the Decentralized Identifier v1.1 context
 (`https://www.w3.org/ns/did/v1`).
           </p>
 
+          <pre class="example nohighlight" title="A controller document without an @context property">
+{
+  "id": "https://controller.example/101",
+  "verificationMethod": [{
+    "id": "https://controller.example/101#key-203947",
+    "type": "JsonWebKey",
+    "controller": "https://controller.example/101",
+    "publicKeyJwk": {
+      "kid": "key-203947",
+      "kty": "EC",
+      "crv": "P-256",
+      "alg": "ES256",
+      "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+      "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+    }
+  }],
+  "authentication": ["#key-20240828"]
+}
+          </pre>
+
           <p>
 Implementations that do not intend to use JSON-LD MAY choose to not include an
 `@context` declaration at the top-level of the document. Whether or not the
@@ -2755,6 +2775,7 @@ and values expressed in [=conforming documents=] interpreted by [=conforming
 processors=] are the same. Any differences in semantics between documents
 processed in either mode are either implementation or specification bugs.
           </p>
+
         </section>
       </section>
 


### PR DESCRIPTION
This PR is an attempt to address issue #54 by adding an example that does not contain an `@context` property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/pull/124.html" title="Last updated on Nov 16, 2024, 9:04 PM UTC (8b6e4f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/controller-document/124/f2baa07...8b6e4f4.html" title="Last updated on Nov 16, 2024, 9:04 PM UTC (8b6e4f4)">Diff</a>